### PR TITLE
Force ssl

### DIFF
--- a/project/settings/prod.py
+++ b/project/settings/prod.py
@@ -1,5 +1,5 @@
 from project.settings.environment import *
 
-
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 SECURE_SSL_REDIRECT = True
 DEBUG = False

--- a/project/settings/prod.py
+++ b/project/settings/prod.py
@@ -1,3 +1,5 @@
 from project.settings.environment import *
 
+
+SECURE_SSL_REDIRECT = True
 DEBUG = False


### PR DESCRIPTION
Setting up HTTPS in Django was super easy. I just added two settings to my production settings file.

``` python
# in ./project/settings/prod.py
SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
SECURE_SSL_REDIRECT = True
SESSION_COOKIE_SECURE = True
CSRF_COOKIE_SECURE = True
```
