### PR TITLE
Steps to Apply section on main splash now horizontally aligned

### DIFF
--- a/frontend/build/css/main.css
+++ b/frontend/build/css/main.css
@@ -3901,6 +3901,18 @@ p.step_headline {
 .apply_steps {
   margin-top: 20px;
 }
+.col-md-3-33 {
+  position: relative;
+  min-height: 1px;
+  padding-left: 15px;
+  padding-right: 15px;
+}
+@media (min-width: 992px) {
+  .col-md-3-33 {
+    float: left;
+    width: 27.75%;
+  }
+}
 .step_headline {
   color: #004A6C;
 }

--- a/frontend/less/custom.less
+++ b/frontend/less/custom.less
@@ -96,7 +96,6 @@ body.public .about_the_service {
   line-height: 1.5;
 }
 
-
 /**Steps to apply**/
 
 p.step_headline{
@@ -106,6 +105,13 @@ p.step_headline{
 .apply_steps{
   margin-top: 20px;
 }
+
+// Custom number of columns for apply steps
+.col-md-3-33{
+    .make-md-column(3.33)
+}
+
+
 .step_headline{
   color:@splash-background;
 }

--- a/frontend/less/custom.less
+++ b/frontend/less/custom.less
@@ -106,11 +106,10 @@ p.step_headline{
   margin-top: 20px;
 }
 
-// Custom number of columns for apply steps
+// Create a column width that takes up 3.33 of 12 columns.
 .col-md-3-33{
     .make-md-column(3.33)
 }
-
 
 .step_headline{
   color:@splash-background;

--- a/frontend/less/mixins.less
+++ b/frontend/less/mixins.less
@@ -1,0 +1,15 @@
+// Generate the medium columns
+.make-md-column(@columns, @gutter: @grid-gutter-width) {
+  position: relative;
+  // Prevent columns from collapsing when empty
+  min-height: 1px;
+  // Inner gutter via padding
+  padding-left:  (@gutter / 2);
+  padding-right: (@gutter / 2);
+
+  // Calculate width based on number of columns available
+  @media (min-width: @screen-md-min) {
+    float: left;
+    width: percentage((@columns / @grid-columns));
+  }
+}

--- a/frontend/less/mixins.less
+++ b/frontend/less/mixins.less
@@ -1,3 +1,4 @@
+// Function borrowed from getbootstrap.com/css/#mixins
 // Generate the medium columns
 .make-md-column(@columns, @gutter: @grid-gutter-width) {
   position: relative;

--- a/templates/main_splash.jinja
+++ b/templates/main_splash.jinja
@@ -70,7 +70,7 @@
 
     <div class="row">
       <div class="apply_steps">
-        <div class="col-xs-12 col-md-3">
+        <div class="col-xs-12 col-md-3-33">
           <div class="step">
             <h4 class="step_headline">{{ content.step_1_headline }}</h4>
             <p class="step_paragraph">{{ content.step_1_paragraph }}</p>
@@ -84,7 +84,7 @@
           </h1>
         </div>
 
-        <div class="col-xs-12 col-md-3">
+        <div class="col-xs-12 col-md-3-33">
           <div class="step">
             <h4 class="step_headline">{{ content.step_2_headline }}</h4>
             <p class="step_paragraph">{{ content.step_2_paragraph }}</p>
@@ -98,7 +98,7 @@
           </h1>
         </div>
 
-        <div class="col-xs-12 col-md-3">
+        <div class="col-xs-12 col-md-3-33">
           <div class="step">
             <h4 class="step_headline">{{ content.step_3_headline }}</h4>
             <p class="step_paragraph">{{ content.step_3_paragraph }}</p>


### PR DESCRIPTION
Before the columns were only occupying 11 of the 12 total columns so the steps weren't aligned.

I borrowed a mixin from the [bootstrap docs](http://getbootstrap.com/css/#mixins) to make a column option that takes up 3.33 of the 12 columns instead of 3.

Before:
![image](https://cloud.githubusercontent.com/assets/3680815/17603060/4a3c6ee0-5fc4-11e6-8a43-50e9fb98ee4a.png)

After:
![image](https://cloud.githubusercontent.com/assets/3680815/17603067/5736b5a6-5fc4-11e6-8bad-08166e840d24.png)
