### PR TITLE
Add scoped completion time fields

### DIFF
--- a/frontend/build/css/main.css
+++ b/frontend/build/css/main.css
@@ -4251,6 +4251,10 @@ pre.address {
   display: inline-block;
   width: 15em;
 }
+.minutes span.stats-total-number,
+.minutes span.stats-total-annot {
+  display: block;
+}
 .stats-total-number {
   font-size: 2em;
   font-weight: 500;

--- a/frontend/less/charts.less
+++ b/frontend/less/charts.less
@@ -2,6 +2,10 @@
 	display: inline-block;
 	width: 15em;
 }
+.minutes span.stats-total-number, .minutes span.stats-total-annot {
+	display: block;	
+}
+
 .stats-total-number {
 	font-size: 2em;
 	font-weight: 500;

--- a/intake/aggregate_serializers.py
+++ b/intake/aggregate_serializers.py
@@ -6,23 +6,25 @@ class PublicStatsSerializer(serializers.Serializer):
     total = fields.FinishedCountField(source='apps')
     weekly_totals = fields.WeeklyTotals(source='apps')
     apps_this_week = fields.AppsThisWeek(source='apps')
-    # mean_completion_time = serializers.SerializerMethodField(
-    #     method_name='get_scoped_mean_time')
-    # median_completion_time = serializers.SerializerMethodField(
-    #     method_name='get_scoped_median_time')
+    mean_completion_time = serializers.SerializerMethodField(
+        method_name='get_scoped_mean_time')
+    median_completion_time = serializers.SerializerMethodField(
+        method_name='get_scoped_median_time')
 
-    # def get_scoped_mean_time(self, data):
-    #     pass
+    def get_scoped_mean_time(self, data):
+        return fields.MeanCompletionTimeField(
+            ).to_representation(data['apps'], data['org'])
 
-    # def get_scoped_median_time(self, data):
-    #     pass
+    def get_scoped_median_time(self, data):
+        return fields.MedianCompletionTimeField(
+            ).to_representation(data['apps'], data['org'])
 
 
 class PrivateStatsSerializer(PublicStatsSerializer):
     channels = fields.Channels(source='apps')
     drop_off = fields.DropOff(source='apps')
     app_error_rate = fields.ErrorRate(source='apps')
-    where_they_heard = fields.ErrorRate(source='apps')
+    where_they_heard = fields.WhereTheyHeard(source='apps')
 
 
 # how do I scope completion times?

--- a/intake/tests/test_aggregate_serializer_fields.py
+++ b/intake/tests/test_aggregate_serializer_fields.py
@@ -2,6 +2,9 @@ from django.test import TestCase as DjangoTestCase
 
 from intake.tests.mock_serialized_apps import apps as all_apps
 from intake import aggregate_serializer_fields as fields
+from intake.constants import Organizations
+
+ALL = dict(slug=Organizations.ALL)
 
 
 class TestFinishedCountField(DjangoTestCase):
@@ -21,14 +24,14 @@ class TestMeanCompletionTimeField(DjangoTestCase):
 
     def test_returns_correct_mean(self):
         field = fields.MeanCompletionTimeField()
-        result = field.to_representation(all_apps)
+        result = field.to_representation(all_apps, ALL)
         expected = 441.5181111111111
         difference = abs(expected - result)
         self.assertTrue(difference < 0.00001)
 
     def test_returns_none_for_empty_list(self):
         field = fields.MeanCompletionTimeField()
-        result = field.to_representation([])
+        result = field.to_representation([], ALL)
         self.assertIsNone(result)
 
 
@@ -36,14 +39,14 @@ class TestMedianCompletionTimeField(DjangoTestCase):
 
     def test_returns_correct_median(self):
         field = fields.MedianCompletionTimeField()
-        result = field.to_representation(all_apps)
+        result = field.to_representation(all_apps, ALL)
         expected = 417.204
         difference = abs(expected - result)
         self.assertTrue(difference < 0.00001)
 
     def test_returns_none_for_empty_list(self):
         field = fields.MedianCompletionTimeField()
-        result = field.to_representation([])
+        result = field.to_representation([], ALL)
         self.assertIsNone(result)
 
 

--- a/intake/views/stats_views.py
+++ b/intake/views/stats_views.py
@@ -48,10 +48,10 @@ def organization_index(serialized_org):
 
 
 def add_stats_for_org(org_data, Serializer):
-    org_apps = org_data.pop('apps', [])
-    input_data = {'apps': org_apps}
-    results = Serializer(input_data).data
+    results = Serializer(org_data).data
     org_data.update(results)
+    org_data.pop('apps')
+    return org_data
 
 
 class Stats(TemplateView):

--- a/templates/stats.jinja
+++ b/templates/stats.jinja
@@ -21,16 +21,20 @@ Numbers for Clear My Record
 </div>
 {% for org_data in stats.org_stats %}
 <div class="stats_block {{ org_data.org.slug }}">
-  <h2>{{ org_data.org.name }}</h2>
-  <div class="stats-single_figure">
-    <span class="stats-total-number">{{ org_data.total }}</span>
-    <span class="stats-total-annot">applications</span>
-  </div>
-  <div class="stats-single_figure">
-    <span class="stats-total-number">{{ org_data.apps_this_week }}</span>
-    <span class="stats-total-annot">this week</span>
-  </div>
   {% if 'drop_off' in org_data %}
+  <h2>{{ org_data.org.name }}</h2>
+  <div class="stats-single_figure minutes">
+    <span class="stats-total-number">{{
+     (org_data.mean_completion_time / 60)|int
+     }} minutes</span>
+    <span class="stats-total-annot">mean completion time</span>
+  </div>
+  <div class="stats-single_figure minutes">
+    <span class="stats-total-number">{{
+     (org_data.median_completion_time / 60)|int
+     }} minutes</span>
+    <span class="stats-total-annot">median completion time</span>
+  </div>
   <div class="stats-single_figure">
     <span class="stats-total-number">{{
      (org_data.app_error_rate * 100)|round(1)


### PR DESCRIPTION
Adds the following two fields. Each is measured using apps that have one sole organization.

- Mean Completion Time. this is unreasonably high because it does not account for computers that submit multiple apps over long periods of time. EBCLC's is the highest because they've submitted multiple apps from the same computer
- Median Completion Time. This is a better estimate of how long it generally takes people to finish the form.

Also removes the org totals and weekly amounts, because these are now readily available in the line charts.