### PR TITLE
Adjust content for nonlive partners

### DIFF
--- a/intake/models/county.py
+++ b/intake/models/county.py
@@ -39,6 +39,9 @@ class County(models.Model):
             # return first receiving agency
         return self.organizations.filter(is_receiving_agency=True).first()
 
+    class Meta:
+        ordering = ['name']
+
     def __str__(self):
         return str(self.name)
 

--- a/templates/partner_list.jinja
+++ b/templates/partner_list.jinja
@@ -12,7 +12,7 @@
   <h2>{{ county.name }} County</h2>
   <ul class="partner_list {{ county.slug }}">
     {%- for organization in county.organizations.all() %}
-    {%- if organization.is_receiving_agency %}
+    {%- if organization.is_receiving_agency and organization.is_accepting_applications %}
     <li class="partner_list-organization">
       <a href="{{ organization.get_absolute_url() }}" class="organization-link">
         {{ organization.name }}

--- a/user_accounts/models/organization.py
+++ b/user_accounts/models/organization.py
@@ -40,6 +40,9 @@ class Organization(models.Model):
     email = models.TextField(blank=True)
     notify_on_weekends = models.BooleanField(default=False)
 
+    class Meta:
+        ordering = ['name']
+
     def __str__(self):
         return str(self.name)
 


### PR DESCRIPTION
## Problems

- Counties and organizations appear in seemingly random order. It should be consistent.
- When non-live counties and orgs are loaded to the production site, they are listed under the `/partners/` URL even if they aren't live or listed elsewhere.

## Solutions
- orders counties and organizations alphabetically by default (note: this does not override hardcoded ordering, which has been used in some places)
- only show counties with live organizations and organizations that are live in the partner list. This uses the `is_accepting_applications` flag on the Organization model.

Counties are filtered based on an aggregation of their constituent organizations' `is_accepting_applications` column:

```python
models.County.objects.annotate(
            live_org_count=Count(
                Case(When(
                    organizations__is_accepting_applications=True, then=1
                ))
            )
).filter(live_org_count__gte=1)
```

```sql
SELECT
	"intake_county"."id",
	"intake_county"."slug",
	"intake_county"."name",
	"intake_county"."description",
	COUNT(
		CASE WHEN
			"user_accounts_organization"."is_accepting_applications" = true
			THEN 1 ELSE NULL END
		) AS "live_org_count"
FROM "intake_county"
	LEFT OUTER JOIN "user_accounts_organization" ON (
		"intake_county"."id" = "user_accounts_organization"."county_id")
GROUP BY "intake_county"."id"
HAVING
	COUNT(
		CASE WHEN
			"user_accounts_organization"."is_accepting_applications" = true
			THEN 1 ELSE NULL END
		) >= 1
ORDER BY "intake_county"."name" ASC
```
