### PR TITLE
Rremove Alameda-specific name and text from declaration letter labels

### DIFF
--- a/formation/fields.py
+++ b/formation/fields.py
@@ -501,10 +501,10 @@ class HasChildren(YesNoField):
 ###
 
 
-class AlamedaDeclarationLetterNote(FormNote):
-    context_key = "alameda_declaration_letter_note"
-    content = _("Create your letter for the Alameda County Judge. This is "
-                "required to complete your appication in Alameda County.")
+class DeclarationLetterNote(FormNote):
+    context_key = "declaration_letter_note"
+    content = _("Create your letter to the judges in the counties you "
+                "applied to. This is required to complete your application.")
 
 
 class DeclarationLetterIntro(MultilineCharField):
@@ -591,7 +591,7 @@ INTAKE_FIELDS = [
     ConsentToRepresent,
     ConsentNote,
 
-    AlamedaDeclarationLetterNote,
+    DeclarationLetterNote,
     DeclarationLetterIntro,
     DeclarationLetterLifeChanges,
     DeclarationLetterActivities,

--- a/formation/forms.py
+++ b/formation/forms.py
@@ -457,7 +457,7 @@ class EBCLCIntakeFormSpec(CombinableOrganizationFormSpec):
 
 class DeclarationLetterFormSpec(CombinableFormSpec):
     fields = {
-        F.AlamedaDeclarationLetterNote,
+        F.DeclarationLetterNote,
         F.DeclarationLetterIntro,
         F.DeclarationLetterLifeChanges,
         F.DeclarationLetterActivities,


### PR DESCRIPTION
Closes #252 

- renamed DeclarationLetterNote() and context_key to drop Alameda from name
- replaced Alameda-specific language with more generic "Create your letter to the judges in the counties you applied to. This is required to complete your application."