### PR TITLE
added status update counts

### DIFF
--- a/intake/services/statistics.py
+++ b/intake/services/statistics.py
@@ -9,18 +9,40 @@ ALL = (constants.Organizations.ALL, 'Total (All Organizations)')
 
 
 def get_status_update_success_metrics():
-    """
-    Returns the total and statustype totals of status updates and notifications
-        total & by org
-        'updates' {
-            'all': Counter(
-                'Total': 23,
-                'No Convictions': 4,
-                'Eligible': 6,
+    """calculates the total number of status updates,
+        including the totals by type of status for all orgs and each org.
 
+    Example output:
 
-            }
-        }
+    [('Total (All Organizations)',
+      [('Total', 20),
+       ('Eligible', 3),
+       ('Passed', 3),
+       ('No Convictions', 3),
+       ('Court Date', 3),
+       ("Can't Proceed", 3),
+       ('Not Eligible', 3),
+       ('Declined', 2)]),
+     ('San Francisco Public Defender',
+      [('Total', 2), ('Declined', 1), ("Can't Proceed", 1)]),
+     ("Alameda County Public Defender's Office",
+      [('Total', 2), ('Eligible', 1), ('Not Eligible', 1)]),
+     ('East Bay Community Law Center',
+      [('Total', 2), ('Passed', 1), ('Court Date', 1)]),
+     ('Contra Costa Public Defender',
+      [('Total', 2), ("Can't Proceed", 1), ('No Convictions', 1)]),
+     ('Monterey County Public Defender',
+      [('Total', 2), ('No Convictions', 1), ('Not Eligible', 1)]),
+     ('Solano County Public Defender',
+      [('Total', 2), ('Eligible', 1), ('Court Date', 1)]),
+     ('San Diego County Public Defender',
+      [('Total', 2), ('Passed', 1), ('Declined', 1)]),
+     ('San Joaquin County Public Defender',
+      [('Total', 2), ("Can't Proceed", 1), ('No Convictions', 1)]),
+     ('Santa Clara County Public Defender',
+      [('Total', 2), ('Eligible', 1), ('Not Eligible', 1)]),
+     ('Fresno County Public Defender',
+      [('Total', 2), ('Passed', 1), ('Court Date', 1)])]
     """
     updates = models.StatusUpdate.objects.all().prefetch_related(
         'application__organization',

--- a/intake/services/statistics.py
+++ b/intake/services/statistics.py
@@ -1,0 +1,56 @@
+"""
+This module handles queries to retrieve common statistics
+"""
+from intake import models, constants
+from collections import Counter
+
+TOTAL = 'Total'
+ALL = (constants.Organizations.ALL, 'Total (All Organizations)')
+
+
+def get_status_update_success_metrics():
+    """
+    Returns the total and statustype totals of status updates and notifications
+        total & by org
+        'updates' {
+            'all': Counter(
+                'Total': 23,
+                'No Convictions': 4,
+                'Eligible': 6,
+
+
+            }
+        }
+    """
+    updates = models.StatusUpdate.objects.all().prefetch_related(
+        'application__organization',
+        'status_type'
+    )
+    orgs = {ALL: Counter()}
+    for update in updates:
+        org = (
+            update.application.organization.slug,
+            update.application.organization.name
+        )
+        status_type = update.status_type.display_name
+        if not orgs.get(org):
+            orgs[org] = Counter()
+        orgs[ALL].update([TOTAL, status_type])
+        orgs[org].update([TOTAL, status_type])
+    data = []
+    sorted_orgs = sorted(
+        orgs.items(),
+        key=lambda entry: constants.DEFAULT_ORGANIZATION_ORDER.index(
+            entry[0][0])
+        )
+    for org_tuple, counter in sorted_orgs:
+        entry = (
+            org_tuple[1],
+            list(sorted(
+                counter.items(),
+                key=lambda n: n[1],
+                reverse=True
+            ))
+        )
+        data.append(entry)
+    return data

--- a/intake/services/statistics.py
+++ b/intake/services/statistics.py
@@ -52,8 +52,9 @@ def get_status_update_success_metrics():
             update.application.organization.name
         )
         status_type = update.status_type.display_name
-        next_steps = update.next_steps.all().values_list(
-            'display_name', flat=True)
+        next_steps = [
+            next_step.display_name for
+            next_step in update.next_steps.all()]
         if not org_status_type_counts.get(org):
             org_status_type_counts[org] = Counter()
         if not org_status_notification_counts.get(org):

--- a/intake/tests/services/test_statistics.py
+++ b/intake/tests/services/test_statistics.py
@@ -11,7 +11,7 @@ class TestGetStatusUpdateSuccessMetrics(TestCase):
     def test_returns_expected_data(self):
         number_of_orgs = Organization.objects.filter(
             is_receiving_agency=True).count()
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(5):
             data = statistics.get_status_update_success_metrics()
         data_dict = dict(data)
         self.assertEqual(len(data), number_of_orgs + 1)

--- a/intake/tests/services/test_statistics.py
+++ b/intake/tests/services/test_statistics.py
@@ -1,0 +1,23 @@
+from django.test import TestCase
+from intake.services import statistics
+from user_accounts.models import Organization
+from intake.tests.base_testcases import ALL_APPLICATION_FIXTURES
+
+
+class TestGetStatusUpdateSuccessMetrics(TestCase):
+
+    fixtures = ALL_APPLICATION_FIXTURES
+
+    def test_returns_expected_data(self):
+        number_of_orgs = Organization.objects.filter(
+            is_receiving_agency=True).count()
+        with self.assertNumQueries(4):
+            data = statistics.get_status_update_success_metrics()
+        data_dict = dict(data)
+        self.assertEqual(len(data), number_of_orgs + 1)
+        self.assertIn(
+            statistics.ALL[1], data_dict)
+        for org_name, counts in data:
+            self.assertIn(
+                statistics.TOTAL,
+                dict(counts))

--- a/intake/views/stats_views.py
+++ b/intake/views/stats_views.py
@@ -4,6 +4,7 @@ from intake import (
     models, serializers, constants, aggregate_serializers,
     permissions
     )
+from intake.services import statistics
 
 
 def is_valid_app(app):
@@ -80,6 +81,12 @@ class Stats(TemplateView):
             Serializer = aggregate_serializers.PrivateStatsSerializer
         for org_data in apps_by_org:
             add_stats_for_org(org_data, Serializer)
+        status_update_data = statistics.get_status_update_success_metrics()
+        if show_private_data:
+            for org_name, counts in status_update_data:
+                for org_data in apps_by_org:
+                    if org_data['org']['name'] == org_name:
+                        org_data['status_updates'] = counts
         context['stats'] = {'org_stats': apps_by_org}
         context['show_private_data'] = show_private_data
         return context

--- a/templates/stats.jinja
+++ b/templates/stats.jinja
@@ -55,6 +55,26 @@ Numbers for Clear My Record
      }}<span class="perc-sign">%</span></span>
     <span class="stats-total-annot">dropoff rate</span>
   </div>
+  {% if org_data.status_updates %}
+  <div class="stats-chart">
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Status Updates</th>
+          <th>Count</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for bucket, count in org_data.status_updates %}
+        <tr>
+          <td>{{ bucket }}</td>
+          <td>{{ count }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% endif %}
   {% if org_data.channels %}
   <div class="stats-chart">
     <table class="table">


### PR DESCRIPTION
Closes #382 

- adds a new module, `intake.services.statistics`, to continue with the services refactoring
- calculates the total number of status updates and the totals by type  of status & next step for all orgs and each org.
- displays these stats in a simple table on the stats page for logged in users (including org users)

![screen shot 2017-02-17 at 12 44 09 pm](https://cloud.githubusercontent.com/assets/451510/23082576/d38da4fe-f50e-11e6-9efd-39bcb92fe7d5.png)
