### PR TITLE
Update pagination on App Index to match mocks

### DIFF
--- a/formation/field_types.py
+++ b/formation/field_types.py
@@ -238,6 +238,9 @@ class ChoiceField(CharField):
             )
 
     def get_display_for_choice(self, value):
+        """Returns the display value for a given choice
+        if not found returns the empty value for this field
+        """
         return self.choice_display_dict.get(value, self.empty_value)
 
     def get_display_choices(self):
@@ -278,9 +281,13 @@ class MultipleChoiceField(ChoiceField):
         return values
 
     def get_display_value(self, use_or=False):
+        """Returns oxford comma list of display values for any valid choices
+        ignores invalid choices
+        """
         return oxford_comma([
             self.get_display_for_choice(choice)
             for choice in self.get_current_value()
+            if self.get_display_for_choice(choice)
         ], use_or)
 
 

--- a/frontend/less/admin.less
+++ b/frontend/less/admin.less
@@ -11,6 +11,9 @@
 	margin: 0;
 	font-weight: inherit;
 }
+.pagination-nav{
+	float: right;
+}
 ul.pagination {
 	margin-top: .5em;
 }

--- a/intake/models/form_submission.py
+++ b/intake/models/form_submission.py
@@ -68,7 +68,6 @@ class FormSubmission(models.Model):
     alternate_phone_number = models.TextField(default="")
     email = models.TextField(default="")
 
-
     # old_uuid is only used for porting legacy applications
     old_uuid = models.CharField(max_length=34, unique=True,
                                 default=gen_uuid)

--- a/intake/services/status_notifications.py
+++ b/intake/services/status_notifications.py
@@ -54,7 +54,7 @@ def send_and_save_new_status(request, notification_data, status_update_data):
     status_update.save()
     status_update.next_steps.add(*next_steps)
     sub = status_update_data['application'].form_submission
-    contact_info = SubmissionsService.get_usable_contact_info(sub)
+    contact_info = sub.get_usable_contact_info()
     notification_intro = get_notification_intro(
         status_update_data['author'].profile)
     default_message = '\n\n'.join([

--- a/intake/services/submissions.py
+++ b/intake/services/submissions.py
@@ -8,6 +8,7 @@ from intake.constants import SMS, EMAIL
 from intake.service_objects import ConfirmationNotification
 from intake.models.form_submission import FORMSUBMISSION_TEXT_SEARCH_FIELDS
 
+
 class MissingAnswersError(Exception):
     pass
 
@@ -75,14 +76,6 @@ def fill_pdfs_for_submission(submission):
         organization__submissions=submission)
     for fillable in fillables:
         fillable.fill_for_submission(submission)
-
-
-def get_usable_contact_info(submission):
-    return {
-        key: value
-        for key, value in submission.get_contact_info().items()
-        if key in [SMS, EMAIL]
-    }
 
 
 def get_paginated_submissions_for_user(

--- a/templates/app_index.jinja
+++ b/templates/app_index.jinja
@@ -20,9 +20,6 @@
       </div>
     </div>
   </div>
-  {%- if page_counter %}
-  {% include "includes/submission_paginator.jinja" %}
-  {%- endif %}
   <div class="row">
     {% if perms.intake.view_application_note %}
       {% include "followup_list.jinja" %}

--- a/templates/includes/submission_paginator.jinja
+++ b/templates/includes/submission_paginator.jinja
@@ -1,9 +1,9 @@
 {%- if submissions.has_other_pages() %}
 <div class="row">
-  <nav aria-label="Page navigation">
-    <h4 class="page_nav_header">
-      Page {{ submissions.number }} of {{ submissions.paginator.num_pages }}
-    </h4>
+  <nav aria-label="Page navigation" class="pagination-nav">
+    <h5 class="page_nav_header">
+      Showing <strong>{{ submissions.start_index() }} - {{ submissions.end_index() }}</strong> of <strong>{{ submissions.paginator.count }}</strong> applications
+    </h5>
     <ul class="pagination pagination-sm">
       {%- if submissions.has_previous() %}
       <li title="Previous page">


### PR DESCRIPTION
Closes #378 

- pagination displays only once on index page
- instead of indicating page number alone(`page 1 of 3`), shows range and number of total applications in index (`1-25 of 200 applications`)

_Also includes bonus commit:_
Closes #383 
- invalid template options are no longer displayed as `[]`
- context for `get_display_for_choice()` and `get_display_value()`