### PR TITLE
ensure that only usable contact info is attached to status notifications

### DIFF
--- a/intake/services/status_notifications.py
+++ b/intake/services/status_notifications.py
@@ -54,7 +54,7 @@ def send_and_save_new_status(request, notification_data, status_update_data):
     status_update.save()
     status_update.next_steps.add(*next_steps)
     sub = status_update_data['application'].form_submission
-    contact_info = SubmissionsService.get_usable_contact_info(sub)
+    contact_info = sub.get_usable_contact_info()
     notification_intro = get_notification_intro(
         status_update_data['author'].profile)
     default_message = '\n\n'.join([

--- a/intake/services/submissions.py
+++ b/intake/services/submissions.py
@@ -8,6 +8,7 @@ from intake.constants import SMS, EMAIL
 from intake.service_objects import ConfirmationNotification
 from intake.models.form_submission import FORMSUBMISSION_TEXT_SEARCH_FIELDS
 
+
 class MissingAnswersError(Exception):
     pass
 
@@ -75,14 +76,6 @@ def fill_pdfs_for_submission(submission):
         organization__submissions=submission)
     for fillable in fillables:
         fillable.fill_for_submission(submission)
-
-
-def get_usable_contact_info(submission):
-    return {
-        key: value
-        for key, value in submission.get_contact_info().items()
-        if key in [SMS, EMAIL]
-    }
 
 
 def get_paginated_submissions_for_user(


### PR DESCRIPTION
Fixes a 🐞 re: usable contact info attachment to status notifications 