### PR TITLE
Update OG image and add include to social_meta

### DIFF
--- a/templates/includes/head.jinja
+++ b/templates/includes/head.jinja
@@ -4,6 +4,7 @@
 <meta name="csrf-token" content="{{ csrf_token }}">
 
 {% block social_meta %}
+	{% include "includes/social_meta.jinja" %}
 {% endblock social_meta %}
 
 <title>{%- block head_title -%}

--- a/templates/includes/social_meta.jinja
+++ b/templates/includes/social_meta.jinja
@@ -21,6 +21,6 @@
 <meta property="og:title" content="{{ content.metadata_title }}">
 <meta property="og:type" content="article">
 <meta property="og:url" content="{{ request.url }}">
-<meta property="og:image" content="{{ static('img/CMR_social_thumbnail.png') }}">
+<meta property="og:image" content="{{ static('img/CMR_share.png') }}">
 <meta property="og:description" content="{{ content.metadata_description }}">
 <meta property="og:site_name" content="{{ content.metadata_author }}">


### PR DESCRIPTION
Quick fix. The social meta template wasn't being included in the designated block, which meant that we lost out on the share image (as well as other OpenGraph / social meta tags).