### PR TITLE
update password reset button text to reflect action

### DIFF
--- a/user_accounts/templates/user_accounts/request_password_reset.jinja
+++ b/user_accounts/templates/user_accounts/request_password_reset.jinja
@@ -11,7 +11,7 @@ Request a password reset
       {% include "includes/csrf_field.jinja" %}
 		{{ macros.render_form_fields(form) }}
 		<p>
-	      <input class="btn btn-lg btn-primary" type="submit" value="Send a Password Reset Link" />
+	      <input class="btn btn-lg btn-primary" type="submit" value="Send a Password Reset Email" />
 		</p>
   </form>
 {% endblock form %}

--- a/user_accounts/templates/user_accounts/request_password_reset.jinja
+++ b/user_accounts/templates/user_accounts/request_password_reset.jinja
@@ -11,7 +11,7 @@ Request a password reset
       {% include "includes/csrf_field.jinja" %}
 		{{ macros.render_form_fields(form) }}
 		<p>
-	      <input class="btn btn-lg btn-primary" type="submit" value="Reset My Password" />
+	      <input class="btn btn-lg btn-primary" type="submit" value="Send a Password Reset Link" />
 		</p>
   </form>
 {% endblock form %}


### PR DESCRIPTION
Closes #36 

The user will receive a link to a password reset page via email, so this text is more accurate to the spirit of the action. 