### PR TITLE
Staff users can search app index, have no pagination

### DIFF
--- a/intake/views/admin_views.py
+++ b/intake/views/admin_views.py
@@ -399,7 +399,10 @@ class CaseBundlePrintoutPDFView(ViewAppDetailsMixin, View):
 
 class ApplicantAutocomplete(autocomplete.Select2QuerySetView):
     def get_queryset(self):
-        qs = models.Application.objects.filter(
+        if self.request.user.is_staff:
+            qs = qs = models.Application.objects.all()
+        else:
+            qs = models.Application.objects.filter(
                 organization=self.request.user.profile.organization)
 
         if self.q:

--- a/intake/views/admin_views.py
+++ b/intake/views/admin_views.py
@@ -65,18 +65,22 @@ class ApplicationIndex(ViewAppDetailsMixin, TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         is_staff = self.request.user.is_staff
-        context['submissions'] = \
-            SubmissionsService.get_paginated_submissions_for_user(
-                self.request.user, self.request.GET.get('page'))
-        context['page_counter'] = \
-            utils.get_page_navigation_counter(
-                page=context['submissions'],
-                wing_size=9)
         context['show_pdf'] = self.request.user.profile.should_see_pdf()
         context['body_class'] = 'admin'
         context['search_form'] = forms.ApplicationSelectForm()
         if is_staff:
             context['ALL_TAG_NAMES'] = TagsService.get_all_used_tag_names()
+            context['submissions'] = \
+                SubmissionsService.get_permitted_submissions(
+                    self.request.user, related_objects=True)
+        else:
+            context['submissions'] = \
+                SubmissionsService.get_paginated_submissions_for_user(
+                    self.request.user, self.request.GET.get('page'))
+            context['page_counter'] = \
+                utils.get_page_navigation_counter(
+                    page=context['submissions'],
+                    wing_size=9)
         return context
 
 


### PR DESCRIPTION
Closes #442 

- Search in App Index now functional for staff users
- Queryset for autocomplete/search is org-limited for org users, no limits for staff users
- Pagination on App Index (temporarily) removed for staff users, remains in place for org users

_Notes:_
Staff users cannot presently leave notes or tags via the App Detail view, and it is cumbersome to paginate through all of the applicants. In addition to closing #442, this is a temporary fix to allow staff users to annotate/tag applications quickly. #466 and #467 are more permanent solutions.