### PR TITLE
mock sf user login should follow standard scheme

### DIFF
--- a/user_accounts/fixtures/mock_profiles.json
+++ b/user_accounts/fixtures/mock_profiles.json
@@ -86,7 +86,7 @@
     "username": "sf_pubdef_user",
     "first_name": "Fake",
     "last_name": "SFPubDef",
-    "email": "bgolder+demo+sf_pubdef@codeforamerica.org",
+    "email": "bgolder+demo+sf_pubdef_user@codeforamerica.org",
     "is_staff": false,
     "is_active": true,
     "date_joined": "2016-06-13T23:12:25Z",


### PR DESCRIPTION
Was `bgolder+demo+sf_pubdef@codeforamerica.org`
This changes it to `bgolder+demo+sf_pubdef_user@codeforamerica.org` so that it matches all the others.

History:
- sf was the first to be added
- we added the automated mocking of accounts later on
- sf's fixture was never updated
- we don't often login to the demo as sf, so we forgot it was different
- @jazmynlatimer couldn't login to test

