### PR TITLE
add Google Tag Manager code to base template

### DIFF
--- a/templates/admin_base.jinja
+++ b/templates/admin_base.jinja
@@ -5,8 +5,19 @@
     <link rel="stylesheet" type="text/css" href="{{ static('css/main.css') }}">
     {% block extra_css_links %}
     {% endblock extra_css_links %}
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-TVDP7Z6');</script>
+    <!-- End Google Tag Manager -->
   </head>
   <body class="{%- block body_class -%}admin{%- endblock body_class -%}">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TVDP7Z6"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     {% block body %}
       {% include "includes/header.jinja" %}
       {% block main %}


### PR DESCRIPTION
Closes #496 

- GTM code added to `<head>` and `<body>` of `admin_base` (with surrounding comments for easy removal if we no longer want to use this)