### PR TITLE
Refactor Makefile, put seed lists in one place

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ test.keepdb:
 	./manage.py test $(SCOPE) \
 		--verbosity 2 --keepdb
 
+
 test.review_app:
 	pip install -r requirements/dev.txt
 	./manage.py migrate --settings project.settings.review_app
@@ -24,6 +25,7 @@ test.review_app:
 		--settings project.settings.review_app \
 		--verbosity 2 --keepdb
 	coverage report -m
+
 
 test.coverage:
 	coverage run \
@@ -38,31 +40,9 @@ test.deluxe:
 		--verbosity 2
 
 
-test.acceptance:
-	python ./manage.py test tests.acceptance
-
-
-test.screenshots:
-	python ./manage.py test \
-		tests.acceptance.test_screenshots \
-		--verbosity 2
-
-deploy.feature:
-	git push -f feature HEAD:master
-	heroku run --app cmr-feature make db.seed
-
-deploy.demo:
-	git push -f demo HEAD:master
-	heroku run --app cmr-demo make db.seed
-
-deploy.prod:
-	git push prod master
-	heroku run --app cmr-prod python manage.py loaddata \
-		counties \
-		organizations \
-		addresses \
-		groups \
-		template_options
+db.seed:
+	python ./manage.py load_essential_data
+	python ./manage.py load_mock_data
 
 
 db.setup:
@@ -70,9 +50,10 @@ db.setup:
 	make db.seed
 
 
-db.pull.demo:
-	dropdb intake --if-exists
-	heroku pg:pull --app cmr-demo DATABASE_URL intake
+db.total_rebuild:
+	dropdb intake
+	createdb intake
+	make db.setup
 
 
 db.dump_fixtures:
@@ -104,46 +85,7 @@ db.dump_fixtures:
 	    --indent 2 \
 	    --format json
 
-db.core_seed:
-	python ./manage.py loaddata \
-		counties \
-		organizations \
-		addresses \
-		mock_profiles \
-		template_options
 
-db.seed:
-	make db.core_seed
-	python ./manage.py loaddata \
-		mock_2_submissions_to_a_pubdef \
-		mock_2_submissions_to_ebclc \
-		mock_2_submissions_to_cc_pubdef \
-		mock_2_submissions_to_sf_pubdef \
-		mock_2_submissions_to_monterey_pubdef \
-		mock_2_submissions_to_solano_pubdef \
-		mock_2_submissions_to_san_diego_pubdef \
-		mock_2_submissions_to_san_joaquin_pubdef \
-		mock_2_submissions_to_santa_clara_pubdef \
-		mock_2_submissions_to_santa_cruz_pubdef \
-		mock_2_submissions_to_fresno_pubdef \
-		mock_2_submissions_to_sonoma_pubdef \
-		mock_2_submissions_to_tulare_pubdef \
-		mock_1_submission_to_multiple_orgs \
-		mock_1_bundle_to_a_pubdef \
-		mock_1_bundle_to_ebclc \
-		mock_1_bundle_to_sf_pubdef \
-		mock_1_bundle_to_cc_pubdef \
-		mock_1_bundle_to_monterey_pubdef \
-		mock_1_bundle_to_solano_pubdef \
-		mock_1_bundle_to_san_diego_pubdef \
-		mock_1_bundle_to_san_joaquin_pubdef \
-		mock_1_bundle_to_santa_clara_pubdef \
-		mock_1_bundle_to_santa_cruz_pubdef \
-		mock_1_bundle_to_fresno_pubdef \
-		mock_1_bundle_to_sonoma_pubdef \
-		mock_1_bundle_to_tulare_pubdef \
-		mock_application_events
-
-
-notebook:
-	python ./manage.py shell_plus --notebook
+db.pull.demo:
+	dropdb intake --if-exists
+	heroku pg:pull --app cmr-demo DATABASE_URL intake

--- a/intake/management/commands/load_essential_data.py
+++ b/intake/management/commands/load_essential_data.py
@@ -1,6 +1,5 @@
 from django.core import management
 from django.core.management.base import BaseCommand
-from django.conf import settings
 
 
 class Command(BaseCommand):
@@ -8,7 +7,10 @@ class Command(BaseCommand):
         "Sets up seeds based on what environment it runs in.")
 
     def handle(self, *args, **kwargs):
-        management.call_command('migrate')
-        management.call_command('load_essential_data')
-        if settings.GENERATE_DUMMY_DATA:
-            management.call_command('load_mock_data')
+        management.call_command(
+            'loaddata',
+            'counties',
+            'organizations',
+            'addresses',
+            'groups',
+            'template_options')

--- a/intake/management/commands/load_essential_data.py
+++ b/intake/management/commands/load_essential_data.py
@@ -1,5 +1,6 @@
 from django.core import management
 from django.core.management.base import BaseCommand
+from project.fixtures_index import ESSENTIAL_DATA_FIXTURES
 
 
 class Command(BaseCommand):
@@ -7,10 +8,4 @@ class Command(BaseCommand):
         "Sets up seeds based on what environment it runs in.")
 
     def handle(self, *args, **kwargs):
-        management.call_command(
-            'loaddata',
-            'counties',
-            'organizations',
-            'addresses',
-            'groups',
-            'template_options')
+        management.call_command('loaddata', *ESSENTIAL_DATA_FIXTURES)

--- a/intake/management/commands/load_mock_data.py
+++ b/intake/management/commands/load_mock_data.py
@@ -2,6 +2,7 @@ from django.core import management
 from django.core.management.base import BaseCommand
 from intake.models import pdfs
 from intake.tests import mock
+from project.fixtures_index import ALL_MOCK_DATA_FIXTURES
 
 
 class Command(BaseCommand):
@@ -10,35 +11,6 @@ class Command(BaseCommand):
 
     def handle(self, *args, **kwargs):
         management.call_command(
-            'loaddata',
-            'mock_profiles',
-            'mock_2_submissions_to_a_pubdef',
-            'mock_2_submissions_to_ebclc',
-            'mock_2_submissions_to_cc_pubdef',
-            'mock_2_submissions_to_sf_pubdef',
-            'mock_2_submissions_to_monterey_pubdef',
-            'mock_2_submissions_to_solano_pubdef',
-            'mock_2_submissions_to_san_diego_pubdef',
-            'mock_2_submissions_to_san_joaquin_pubdef',
-            'mock_2_submissions_to_santa_clara_pubdef',
-            'mock_2_submissions_to_santa_cruz_pubdef',
-            'mock_2_submissions_to_fresno_pubdef',
-            'mock_2_submissions_to_sonoma_pubdef',
-            'mock_2_submissions_to_tulare_pubdef',
-            'mock_1_submission_to_multiple_orgs',
-            'mock_1_bundle_to_a_pubdef',
-            'mock_1_bundle_to_ebclc',
-            'mock_1_bundle_to_sf_pubdef',
-            'mock_1_bundle_to_cc_pubdef',
-            'mock_1_bundle_to_monterey_pubdef',
-            'mock_1_bundle_to_solano_pubdef',
-            'mock_1_bundle_to_san_diego_pubdef',
-            'mock_1_bundle_to_san_joaquin_pubdef',
-            'mock_1_bundle_to_santa_clara_pubdef',
-            'mock_1_bundle_to_santa_cruz_pubdef',
-            'mock_1_bundle_to_fresno_pubdef',
-            'mock_1_bundle_to_sonoma_pubdef',
-            'mock_1_bundle_to_tulare_pubdef',
-            'mock_application_events')
+            'loaddata', *ALL_MOCK_DATA_FIXTURES)
         if pdfs.FillablePDF.objects.count() == 0:
             mock.fillable_pdf()

--- a/intake/management/commands/load_mock_data.py
+++ b/intake/management/commands/load_mock_data.py
@@ -1,0 +1,44 @@
+from django.core import management
+from django.core.management.base import BaseCommand
+from intake.models import pdfs
+from intake.tests import mock
+
+
+class Command(BaseCommand):
+    help = str(
+        "Sets up seeds based on what environment it runs in.")
+
+    def handle(self, *args, **kwargs):
+        management.call_command(
+            'loaddata',
+            'mock_profiles',
+            'mock_2_submissions_to_a_pubdef',
+            'mock_2_submissions_to_ebclc',
+            'mock_2_submissions_to_cc_pubdef',
+            'mock_2_submissions_to_sf_pubdef',
+            'mock_2_submissions_to_monterey_pubdef',
+            'mock_2_submissions_to_solano_pubdef',
+            'mock_2_submissions_to_san_diego_pubdef',
+            'mock_2_submissions_to_san_joaquin_pubdef',
+            'mock_2_submissions_to_santa_clara_pubdef',
+            'mock_2_submissions_to_santa_cruz_pubdef',
+            'mock_2_submissions_to_fresno_pubdef',
+            'mock_2_submissions_to_sonoma_pubdef',
+            'mock_2_submissions_to_tulare_pubdef',
+            'mock_1_submission_to_multiple_orgs',
+            'mock_1_bundle_to_a_pubdef',
+            'mock_1_bundle_to_ebclc',
+            'mock_1_bundle_to_sf_pubdef',
+            'mock_1_bundle_to_cc_pubdef',
+            'mock_1_bundle_to_monterey_pubdef',
+            'mock_1_bundle_to_solano_pubdef',
+            'mock_1_bundle_to_san_diego_pubdef',
+            'mock_1_bundle_to_san_joaquin_pubdef',
+            'mock_1_bundle_to_santa_clara_pubdef',
+            'mock_1_bundle_to_santa_cruz_pubdef',
+            'mock_1_bundle_to_fresno_pubdef',
+            'mock_1_bundle_to_sonoma_pubdef',
+            'mock_1_bundle_to_tulare_pubdef',
+            'mock_application_events')
+        if pdfs.FillablePDF.objects.count() == 0:
+            mock.fillable_pdf()

--- a/intake/tests/base_testcases.py
+++ b/intake/tests/base_testcases.py
@@ -7,47 +7,26 @@ from user_accounts.tests.base_testcases import AuthIntegrationTestCase
 from intake import models
 from intake.tests import mock
 
+from project.fixtures_index import (
+    ESSENTIAL_DATA_FIXTURES,
+    MOCK_USER_ACCOUNT_FIXTURES,
+    MOCK_APPLICATION_FIXTURES,
+    MOCK_EVENT_FIXTURES,
+    MOCK_BUNDLE_FIXTURES
+)
+
+
 DELUXE_TEST = os.environ.get('DELUXE_TEST', False)
 
 
-ALL_APPLICATION_FIXTURES = [
-    'counties',
-    'organizations',
-    'addresses',
-    'mock_profiles',
-    'mock_2_submissions_to_a_pubdef',
-    'mock_2_submissions_to_ebclc',
-    'mock_2_submissions_to_cc_pubdef',
-    'mock_2_submissions_to_sf_pubdef',
-    'mock_2_submissions_to_monterey_pubdef',
-    'mock_2_submissions_to_solano_pubdef',
-    'mock_2_submissions_to_san_diego_pubdef',
-    'mock_2_submissions_to_san_joaquin_pubdef',
-    'mock_2_submissions_to_santa_clara_pubdef',
-    'mock_2_submissions_to_fresno_pubdef',
-    'mock_2_submissions_to_santa_cruz_pubdef',
-    'mock_2_submissions_to_sonoma_pubdef',
-    'mock_2_submissions_to_tulare_pubdef',
-    'mock_1_submission_to_multiple_orgs',
-    'mock_application_events',
-    'template_options'
-]
+ALL_APPLICATION_FIXTURES = (
+    ESSENTIAL_DATA_FIXTURES +
+    MOCK_USER_ACCOUNT_FIXTURES +
+    MOCK_APPLICATION_FIXTURES +
+    MOCK_EVENT_FIXTURES
+)
 
-ALL_BUNDLES = [
-    'mock_1_bundle_to_a_pubdef',
-    'mock_1_bundle_to_ebclc',
-    'mock_1_bundle_to_sf_pubdef',
-    'mock_1_bundle_to_cc_pubdef',
-    'mock_1_bundle_to_monterey_pubdef',
-    'mock_1_bundle_to_solano_pubdef',
-    'mock_1_bundle_to_san_diego_pubdef',
-    'mock_1_bundle_to_san_joaquin_pubdef',
-    'mock_1_bundle_to_santa_clara_pubdef',
-    'mock_1_bundle_to_sonoma_pubdef',
-    'mock_1_bundle_to_fresno_pubdef',
-    'mock_1_bundle_to_tulare_pubdef',
-    'mock_1_bundle_to_santa_cruz_pubdef',
-]
+ALL_BUNDLES = MOCK_BUNDLE_FIXTURES
 
 
 class IntakeDataTestCase(AuthIntegrationTestCase):

--- a/project/fixtures_index.py
+++ b/project/fixtures_index.py
@@ -1,0 +1,66 @@
+# These contain production data that impacts logic
+# no dependencies (besides DB migration)
+ESSENTIAL_DATA_FIXTURES = (
+    'counties',
+    'organizations',
+    'addresses',
+    'groups',
+    'template_options',
+)
+
+# These contain fake accounts for each org
+MOCK_USER_ACCOUNT_FIXTURES = (
+    'mock_profiles',
+)
+
+# These are form submissions & fake applicant data
+# depends on ESSENTIAL_DATA_FIXTURES
+MOCK_APPLICATION_FIXTURES = (
+    'mock_2_submissions_to_a_pubdef',
+    'mock_2_submissions_to_ebclc',
+    'mock_2_submissions_to_cc_pubdef',
+    'mock_2_submissions_to_sf_pubdef',
+    'mock_2_submissions_to_monterey_pubdef',
+    'mock_2_submissions_to_solano_pubdef',
+    'mock_2_submissions_to_san_diego_pubdef',
+    'mock_2_submissions_to_san_joaquin_pubdef',
+    'mock_2_submissions_to_santa_clara_pubdef',
+    'mock_2_submissions_to_santa_cruz_pubdef',
+    'mock_2_submissions_to_fresno_pubdef',
+    'mock_2_submissions_to_sonoma_pubdef',
+    'mock_2_submissions_to_tulare_pubdef',
+    'mock_1_submission_to_multiple_orgs',
+)
+
+# These are fake case events (submitted, opened, processed, etc.)
+# depends on MOCK_APPLICATION_FIXTURES and MOCK_USER_ACCOUNT_FIXTURES
+MOCK_EVENT_FIXTURES = (
+    'mock_application_events',
+)
+
+# These are fake bundles of applications
+# depends on MOCK_APPLICATION_FIXTURES
+MOCK_BUNDLE_FIXTURES = (
+    'mock_1_bundle_to_a_pubdef',
+    'mock_1_bundle_to_ebclc',
+    'mock_1_bundle_to_sf_pubdef',
+    'mock_1_bundle_to_cc_pubdef',
+    'mock_1_bundle_to_monterey_pubdef',
+    'mock_1_bundle_to_solano_pubdef',
+    'mock_1_bundle_to_san_diego_pubdef',
+    'mock_1_bundle_to_san_joaquin_pubdef',
+    'mock_1_bundle_to_santa_clara_pubdef',
+    'mock_1_bundle_to_santa_cruz_pubdef',
+    'mock_1_bundle_to_fresno_pubdef',
+    'mock_1_bundle_to_sonoma_pubdef',
+    'mock_1_bundle_to_tulare_pubdef',
+)
+
+# These all the fake mocked data
+# depends on ESSENTIAL_DATA_FIXTURES
+ALL_MOCK_DATA_FIXTURES = (
+    MOCK_USER_ACCOUNT_FIXTURES +
+    MOCK_APPLICATION_FIXTURES +
+    MOCK_BUNDLE_FIXTURES +
+    MOCK_EVENT_FIXTURES
+)


### PR DESCRIPTION
Closes #571 

This tries to solve the problem of loading essential production data and mock data reliably both locally and on heroku deployments.

Fixtures are now enumerated in one file, `project/fixture_index.py`. Management commands and tests can both import lists of fixtures from this file. It looks something like this:

```python
# These contain production data that impacts logic
# no dependencies (besides DB migration)
ESSENTIAL_DATA_FIXTURES = (
    'counties',
    'organizations',
    'addresses',
    'groups',
    'template_options',
)

# These contain fake accounts for each org
# depends on ESSENTIAL_DATA_FIXTURES
MOCK_USER_ACCOUNT_FIXTURES = (
    'mock_profiles',
)

# These are form submissions & fake applicant data
# depends on ESSENTIAL_DATA_FIXTURES
MOCK_APPLICATION_FIXTURES = (
    'mock_2_submissions_to_a_pubdef',
    'mock_2_submissions_to_ebclc',
    'mock_2_submissions_to_cc_pubdef',
    ...
```

I then out two portions of the `manage.py heroku_release` command into two subcommands:
- `manage.py load_essential_data`
- `manage.py load_mock_data`

These two subcommands are shared by the `Makefile`:

```make
db.seed:
	python ./manage.py load_essential_data
	python ./manage.py load_mock_data

db.setup:
	python ./manage.py migrate
	make db.seed
```

The `heroku_release` command now looks like this:

```python
class Command(BaseCommand):
    help = str(
        "Sets up seeds based on what environment it runs in.")

    def handle(self, *args, **kwargs):
        management.call_command('migrate')
        management.call_command('load_essential_data')
        if settings.GENERATE_DUMMY_DATA:
            management.call_command('load_mock_data')
```
