### PR TITLE
properly filter status types for the status update form, closes #618

### DIFF
--- a/intake/forms/status_update_forms.py
+++ b/intake/forms/status_update_forms.py
@@ -15,7 +15,8 @@ class StatusUpdateForm(forms.ModelForm):
         queryset=models.Application.objects.all())
     status_type = forms.ModelChoiceField(
         widget=forms.RadioSelect,
-        queryset=models.StatusType.objects.filter(is_active=True),
+        queryset=models.StatusType.objects.filter(
+            is_active=True, is_a_status_update_choice=True),
         empty_label=None)
     next_steps = forms.ModelMultipleChoiceField(
         widget=forms.CheckboxSelectMultiple,

--- a/intake/tests/views/test_status_update_views.py
+++ b/intake/tests/views/test_status_update_views.py
@@ -140,6 +140,11 @@ class TestCreateStatusUpdateFormView(StatusUpdateViewBaseTestCase):
                 kwargs=dict(submission_id=self.sub.id)),
             fetch_redirect_response=False)
 
+    def test_does_not_see_incorrect_status_type_options(self):
+        self.be_apubdef_user()
+        response = self.get_create_page()
+        self.assertNotContains(response, 'Transferred')
+
 
 class TestReviewStatusNotificationFormView(StatusUpdateViewBaseTestCase):
 


### PR DESCRIPTION
"Transferred" was unintentionally included as a possible status type option on the create status update form. This was selected by a partner, and then caused errors downstream today.

We need to pull this option immediately. This status update fixes the option filtering for new status updates in the form and includes a regression test.

```python
# add is_a_status_update_choice=True to the filter
class StatusUpdateForm(forms.ModelForm):
    ...
    status_type = forms.ModelChoiceField(
        widget=forms.RadioSelect,
        queryset=models.StatusType.objects.filter(
            is_active=True, is_a_status_update_choice=True),
        empty_label=None)
```