### PR TITLE
Show org membership in multiple locations for users

### DIFF
--- a/frontend/build/css/main.css
+++ b/frontend/build/css/main.css
@@ -3716,7 +3716,8 @@ section.content.application_form {
 }
 .field input,
 .field textarea,
-.field .field-preceding_text {
+.field .field-preceding_text,
+.field span.field-display_value {
   font-weight: 400;
   font-size: 1.25em;
 }

--- a/frontend/less/forms.less
+++ b/frontend/less/forms.less
@@ -30,7 +30,7 @@ section.content.application_form {
 	ol { padding-left: 1.5em; }
 }
 .field {
-	input, textarea, .field-preceding_text {
+	input, textarea, .field-preceding_text, span.field-display_value {
 		font-weight: 400;
 		font-size: 1.25em;
 	}

--- a/user_accounts/models/user_profile.py
+++ b/user_accounts/models/user_profile.py
@@ -15,10 +15,17 @@ class UserProfile(models.Model):
     should_get_notifications = models.BooleanField(default=False)
 
     def get_display_name(self):
-        return self.name or self.user.email
+        name_display = self.name or self.user.email
+        return "{} at {}".format(
+            name_display, self.organization.name)
 
     def __str__(self):
-        return self.get_display_name()
+        display = self.get_display_name()
+        display += ", {}".format(self.user.email)
+        if self.should_get_notifications:
+            self.user.email
+            display += " (gets notifications)"
+        return display
 
     @classmethod
     def create_from_invited_user(cls, user, invitation=None, **kwargs):

--- a/user_accounts/templates/user_accounts/userprofile_form.jinja
+++ b/user_accounts/templates/user_accounts/userprofile_form.jinja
@@ -8,12 +8,25 @@ Account settings
 
 {% block form %}
 			<form action="" method="post">
+			    
+			    <div class="field organization">
+			    	<label class="field-wrapping_label">
+			    		<span class="field-display_text">Organization</span>
+			    		<span class="field-display_value">
+			    			{{ user.profile.organization.name }}
+			    		</span>
+			    		
+			    	</label>
+			    </div>
 					{% csrf_token %}
 			    {{ macros.render_form_fields(form) }}
+		
 			    <p>
 			    	<input class="btn btn-lg btn-primary" type="submit" value="Update" />	
 			    </p>
 			</form>
+
+
 			
 			<ul class="profile_menu">
 				<li class="profile_menu-item">

--- a/user_accounts/tests/mock.py
+++ b/user_accounts/tests/mock.py
@@ -91,7 +91,7 @@ def add_cfa_seed_users():
     username = 'monitor_user'
     email = 'bgolder+demo+{}@codeforamerica.org'.format(username)
     user = auth_models.User.objects.filter(username=username).first()
-    name = 'Fake Monitor User',
+    name = 'Fake Monitor User'
     if not user:
         user = auth_models.User.objects.create_user(
             username=username,

--- a/user_accounts/tests/models/test_user_profile.py
+++ b/user_accounts/tests/models/test_user_profile.py
@@ -13,6 +13,15 @@ class TestUserProfile(IntakeDataTestCase):
         'mock_1_bundle_to_cc_pubdef', 'template_options'
     ]
 
+    def test_shows_org_name_when_printed(self):
+        default_print_display = str(self.sf_pubdef_user.profile)
+        display_name = self.sf_pubdef_user.profile.get_display_name()
+        org_name = self.sf_pubdef_user.profile.organization.name
+        self.assertIn(org_name, default_print_display)
+        self.assertTrue(self.sf_pubdef_user.profile.should_get_notifications)
+        self.assertIn("gets notifications", default_print_display)
+        self.assertIn(org_name, display_name)
+
     def test_user_should_see_pdf(self):
         self.assertTrue(self.sf_pubdef_user.profile.should_see_pdf())
         self.assertTrue(self.cfa_user.profile.should_see_pdf())

--- a/user_accounts/tests/test_auth_integration.py
+++ b/user_accounts/tests/test_auth_integration.py
@@ -96,10 +96,7 @@ class TestUserAccounts(AuthIntegrationTestCase):
         users = User.objects.filter(email=self.example_user['email'])
         self.assertEqual(len(users), 1)
         self.assertTrue(users[0].is_authenticated)
-        self.assertEqual(
-            get_user_display(
-                users[0]),
-            self.example_user['email'])
+        self.assertIn(self.example_user['email'], get_user_display(users[0]))
         self.assertIn(self.groups[0], users[0].groups.all())
 
     def test_user_can_add_info_in_profile_view(self):

--- a/user_accounts/tests/test_views.py
+++ b/user_accounts/tests/test_views.py
@@ -1,0 +1,14 @@
+from user_accounts.tests.base_testcases import AuthIntegrationTestCase
+from django.core.urlresolvers import reverse
+from project.fixtures_index import (
+    ESSENTIAL_DATA_FIXTURES, MOCK_USER_ACCOUNT_FIXTURES
+)
+
+
+class TestUserProfileView(AuthIntegrationTestCase):
+    fixtures = ESSENTIAL_DATA_FIXTURES + MOCK_USER_ACCOUNT_FIXTURES
+
+    def test_can_see_org_in_auth_bar(self):
+        user = self.be_sfpubdef_user()
+        response = self.client.get(reverse('user_accounts-profile'))
+        self.assertContains(response, user.profile.organization.name)


### PR DESCRIPTION
Closes #674

Changes:
- Printing a `UserProfile` instance shows org membership, email, and notifications status.
- The default logged in user status display show organization membership
- the user profile page shows organization membership
- includes automated tests for all above changes


![screen shot 2017-04-06 at 1 32 40 pm](https://cloud.githubusercontent.com/assets/451510/24774585/5c8e3d60-1ace-11e7-9514-d272ef088419.png)
