### PR TITLE
Reduce app status confusion

### DIFF
--- a/intake/models/application_bundle.py
+++ b/intake/models/application_bundle.py
@@ -1,7 +1,7 @@
 
 import logging
 from urllib.parse import urljoin
-
+from project.jinja2 import externalize_url
 from django.db import models
 from django.utils import timezone as timezone_utils
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -61,4 +61,4 @@ class ApplicationBundle(models.Model):
             kwargs=dict(bundle_id=self.id))
 
     def get_external_url(self):
-        return urljoin(settings.DEFAULT_HOST, self.get_absolute_url())
+        return externalize_url(self.get_absolute_url())

--- a/intake/notifications.py
+++ b/intake/notifications.py
@@ -261,7 +261,7 @@ slack_submission_transferred = SlackTemplateNotification(
     {'action': 'transferred'},
     message_template_path="slack/submission_action.jinja")
 
-# count, bundle
+# count, bundle, bundle_url, app_index_url
 front_email_daily_app_bundle = FrontEmailNotification(
     subject_template=_(
         "{{current_local_time('%a %b %-d, %Y')}}: "

--- a/intake/services/bundles.py
+++ b/intake/services/bundles.py
@@ -1,5 +1,6 @@
 import logging
 import intake
+from project.jinja2 import external_reverse
 from intake import notifications
 from intake.utils import is_the_weekend
 from intake.models import (
@@ -107,10 +108,11 @@ def create_bundles_and_send_notifications_to_orgs():
             notifications.front_email_daily_app_bundle.send(
                 to=emails,
                 count=len(subs),
-                bundle_url=bundle_url)
+                bundle_url=bundle_url,
+                app_index_url=external_reverse('intake-app_index'))
             ApplicationLogEntry.log_referred(ids, user=None, organization=org)
             notifications.slack_app_bundle_sent.send(
                 submissions=subs,
                 emails=emails,
-                bundle_url=bundle_url
+                bundle_url=bundle_url,
             )

--- a/intake/tests/test_notifications.py
+++ b/intake/tests/test_notifications.py
@@ -1,7 +1,8 @@
 from unittest import TestCase as BaseTestCase
 from unittest.mock import Mock, patch
 from django.test import TestCase as DjangoTestCase, override_settings
-
+from project.jinja2 import external_reverse
+from django.core.urlresolvers import reverse
 from django.core import mail
 from django.conf import settings
 import json
@@ -244,7 +245,9 @@ They want to be contacted via text message and email
             current_local_time=current_time,
             bundle_url="something.com/applications/bundle/1/"
         )
+        app_index_url = external_reverse('intake-app_index')
         self.assertIn(expected_body, content.body)
+        self.assertIn(app_index_url, content.body)
         self.assertEqual(expected_subject, content.subject)
 
     @override_settings(DEFAULT_HOST='something.com')

--- a/project/jinja2.py
+++ b/project/jinja2.py
@@ -1,12 +1,22 @@
 from django.contrib.humanize.templatetags import humanize
 from django.core.urlresolvers import reverse, reverse_lazy
 import phonenumbers
+from django.conf import settings
 from jinja2 import Environment
+from urllib.parse import urljoin
 from datetime import datetime
 from pytz import timezone
 from jinja2 import Markup
 from django.utils.html import mark_safe
 from rest_framework.renderers import JSONRenderer
+
+
+def externalize_url(url):
+    return urljoin(settings.DEFAULT_HOST, url)
+
+
+def external_reverse(view_name):
+    return externalize_url(reverse(view_name))
 
 
 def to_json(data):

--- a/templates/email/app_bundle_email.jinja
+++ b/templates/email/app_bundle_email.jinja
@@ -5,6 +5,10 @@ As of {{ current_local_time('%-I:%M %p %Z on %A %b %-d') }}, you have
 You can review and print them at this link:
     {{ bundle_url }}
 
+
+If you'd like to search through all Clear My Record applications, you can access all applications at this link:
+    {{ app_index_url }}
+
 If you have any questions or concerns, email us at clearmyrecord@codeforamerica.org and Jazmyn or Ben will get back to you right away.
 
 Best,


### PR DESCRIPTION
Changes:

- add app index link to bundle email, closes #669
- creates new utility functions in `project/jinja2.py`, `externalize_url(url)`, and `external_reverse(view_name)`.