### PR TITLE
Send less data to mixpanel

### DIFF
--- a/intake/tests/models/test_application_event.py
+++ b/intake/tests/models/test_application_event.py
@@ -1,0 +1,37 @@
+from unittest.mock import patch
+from django.test import TestCase
+
+from intake import models
+from intake.tests import factories
+
+
+class TestApplicationEvent(TestCase):
+
+    @patch('intake.models.application_event.log_to_mixpanel')
+    def test_that_pii_and_sensitive_info_is_not_sent_to_mixpane(
+            self, mixpanel):
+        sub = factories.FormSubmissionFactory.create()
+        for log_call in ('log_followup_sent', 'log_confirmation_sent'):
+            getattr(models.ApplicationEvent, log_call)(
+                sub.applicant_id,
+                contact_info=dict(
+                    sms='5555555555',
+                    email='someone@nowhere.horse'),
+                message_content=dict(
+                    subject='*^ d34thsT4R 5ch3M4tikz --*$#',
+                    body=str("                        "
+                             "      .#########.       "
+                             "    ###############     "
+                             "   #####------######    "
+                             "   ###/.........\####   "
+                             "  ####|.........|#####  "
+                             "  ####|..(*)....|#####  "
+                             "   ####\......./#####   "
+                             "    #####-----######    "
+                             "     ########[x]###     "
+                             "       .########.       "
+                             "                        ")))
+            mock_args, mock_kwargs = mixpanel.delay.call_args
+            applicant_id, name, data = mock_args
+            self.assertEqual(type(data['contact_info']), list)
+            self.assertNotIn('message_content', data)

--- a/intake/tests/services/test_followups.py
+++ b/intake/tests/services/test_followups.py
@@ -46,7 +46,7 @@ class TestGetSubmissionsDueForFollowups(TestCase):
             applicant=applicant)
         models.ApplicationEvent.log_followup_sent(
             applicant.id,
-            contact_info=sub_w_followup.answers['email'],
+            contact_info=dict(email=sub_w_followup.answers['email']),
             message_content="hey how are things going?")
         # if we grab subs that need followups
         results = FollowupsService.get_submissions_due_for_follow_ups()
@@ -75,7 +75,7 @@ class TestGetSubmissionsDueForFollowups(TestCase):
         followed_up_sub.save()
         models.ApplicationEvent.log_followup_sent(
             applicant.id,
-            contact_info=followed_up_sub.answers['email'],
+            contact_info=dict(email=followed_up_sub.answers['email']),
             message_content="hey how are things going?")
         # when we get submissions due for follow ups,
         results = list(FollowupsService.get_submissions_due_for_follow_ups(


### PR DESCRIPTION
Changes:

- adds a step to mixpanel logging of `ApplicationEvent` objects that allows for filtering out data which should not be sent. Closes #654 
