### PR TITLE
Clear session data after form submission

### DIFF
--- a/intake/views/application_form_views.py
+++ b/intake/views/application_form_views.py
@@ -181,6 +181,7 @@ class RAPSheetInstructions(TemplateView, base_views.GetFormSessionDataMixin):
                 context['organizations'] = submission.organizations.all()
                 context['qualifies_for_fee_waiver'] = \
                     submission.qualifies_for_fee_waiver()
+            self.clear_session_data('applicant_id')
         return context
 
 

--- a/intake/views/application_form_views.py
+++ b/intake/views/application_form_views.py
@@ -164,6 +164,7 @@ class Thanks(TemplateView, base_views.GetFormSessionDataMixin):
             context.update(
                 organizations=sub.organizations.all()
             )
+        self.clear_session_data('applicant_id')
         return context
 
 

--- a/intake/views/session_view_base.py
+++ b/intake/views/session_view_base.py
@@ -54,6 +54,12 @@ class GetFormSessionDataMixin:
     def get_session_data(self):
         return dict(**self.request.session.get(self.session_storage_key, {}))
 
+    def clear_session_data(self, *keys):
+        existing_keys = list(self.request.session.keys())
+        for key_to_delete in [self.session_storage_key, *keys]:
+            if key_to_delete in existing_keys:
+                del self.request.session[key_to_delete]
+
     def get_counties(self):
         session_data = self.get_session_data()
         county_slugs = session_data.get('counties', [])

--- a/intake/views/session_view_base.py
+++ b/intake/views/session_view_base.py
@@ -44,10 +44,7 @@ class GetFormSessionDataMixin:
         try:
             self.check_session_data_validity()
         except NoCountyCookiesError as err:
-            notifications.slack_simple.send(
-                "ApplicationError!\n" + str(err))
             logger.error(err)
-            messages.error(self.request, GENERIC_USER_ERROR_MESSAGE)
             return redirect(reverse('intake-apply'))
         return super().dispatch(request, *args, **kwargs)
 

--- a/project/jinja2.py
+++ b/project/jinja2.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from pytz import timezone
 from jinja2 import Markup
 from django.utils.html import mark_safe
+from markupsafe import escape
 from rest_framework.renderers import JSONRenderer
 
 
@@ -91,7 +92,7 @@ class Linkifier:
     def build_link(self, lookup):
         url = self.links[lookup]
         return '<a href="{}">{}</a>'.format(
-            url, lookup)
+            url, escape(lookup))
 
     def __call__(self, content):
         output = content


### PR DESCRIPTION
Closes #503 

_No migrations_

Changes:
- new method on session view base, `clear_session_data`
- Thanks page and rap sheet page will pull session data, and then clear the session after pulling the data.
- make sure linkify escapes link text

UAT for incognito browser _and_ for regular browser (should work identically):
1.  Apply, submit, hit back (or start new form) and not find previous data stored in the form. Hitting back after submitting should take you to the select counties page.
    - [x] For Alameda Pub Def
    - [x] SF Pub Def
    - [x] EBCLC
2. Apply, fill out some data, go to letter, don't submit, hit back and _should_ find the data still stored in the form.
    - [x] For Alameda Pub Def

- [x] UAT for all of the above on regular browser session
- [x] UAT for all of the above on incognito browser session