### PR TITLE
convert old session data values that are not lists to lists

### DIFF
--- a/intake/tests/test_utils.py
+++ b/intake/tests/test_utils.py
@@ -100,3 +100,5 @@ class TestGetFormDataFromSession(TestCase):
         fetched = utils.get_form_data_from_session(
             request, 'form_in_progress')
         self.assertEqual(fetched['confirm_county_selection'], 'yes')
+        self.assertEqual(
+            fetched.getlist('counties'), ['alameda', 'contracosta'])

--- a/intake/tests/test_utils.py
+++ b/intake/tests/test_utils.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 from django.core.paginator import Paginator
 from intake import utils
 from django.test.testcases import _AssertNumQueriesContext
+from django.test import RequestFactory
 
 
 class TestGetPageNavigationCounter(TestCase):
@@ -85,3 +86,17 @@ class AssertNumQueriesLessThanContext(_AssertNumQueriesContext):
                 )
             )
         )
+
+
+class TestGetFormDataFromSession(TestCase):
+
+    def test_get_old_formatted_form_data_from_session(self):
+        old_session_data = {
+            'counties': ['alameda', 'contracosta'],
+            'confirm_county_selection': 'yes'}
+        request = RequestFactory().get('/apply')
+        request.session = {'form_in_progress': old_session_data}
+        # store this @ session key before calling get_form_data_from_session
+        fetched = utils.get_form_data_from_session(
+            request, 'form_in_progress')
+        self.assertEqual(fetched['confirm_county_selection'], 'yes')

--- a/intake/utils.py
+++ b/intake/utils.py
@@ -61,6 +61,8 @@ def get_form_data_from_session(request, session_key):
     raw_dict = request.session.get(session_key, {})
     qdict = QueryDict('', mutable=True)
     for key, items in raw_dict.items():
+        if type(items) is not list:
+            items = [items]
         qdict.setlist(key, items)
     return qdict
 


### PR DESCRIPTION
Fixes the issue that was logged on Friday during UAT (`Exception Type: TypeError at /apply/
Exception Value: 'int' object is not iterable`). 

For non-list values stored in session data, converts to list. Previously, a value of `yes` on `confirm_county_selection` was improperly being stored as `['y','e','s']` -- with the changes in this PR, it is now `'yes'` as expected.