### PR TITLE
SB set up for go-live, plus small edit to savings field CSS

### DIFF
--- a/intake/constants.py
+++ b/intake/constants.py
@@ -209,6 +209,9 @@ COUNTY_CHOICES = (
     (Counties.SONOMA, _(
             'Sonoma County (near Santa Rosa, Petaluma, Sonoma, '
             'Sebastopol, Bodega Bay, Healdsburg, or Cloverdale)')),
+    (Counties.SANTA_BARBARA, _(
+        'Santa Barbara County (near Santa Maria, Santa Barbara, Goleta, '
+        'Carpinteria, Solvang, and Lompoc)')),
 )
 
 if SCOPE_TO_LIVE_COUNTIES and len(COUNTY_CHOICES) == 3:
@@ -230,9 +233,6 @@ if not SCOPE_TO_LIVE_COUNTIES:
             'Ventura County (near Oxnard, Thousand Oaks, Simi Valley, '
             'Camarillo, Ojai, Moorpark, Fillmore, Ojai, Santa Paula, or '
             'Ventura)')),
-        (Counties.SANTA_BARBARA, _(
-            'Santa Barbara County (near Santa Maria, Santa Barbara, Goleta, '
-            'Carpinteria, Solvang, and Lompoc)')),
     )
 
 COUNTY_CHOICES = sorted(COUNTY_CHOICES, key=lambda item: item[1])

--- a/intake/static/intake/less/forms.less
+++ b/intake/static/intake/less/forms.less
@@ -167,7 +167,7 @@ button[type="submit"].action-back { .btn-default; .btn-lg; }
 .household_size .field-input_wrapper { .people-count; }
 .dependents .field-input_wrapper { .people-count; }
 
-.monthly_income .field-input_wrapper, .monthly_expenses .field-input_wrapper, .how_much_savings .field-input_wrapper {
+.monthly_income .field-input_wrapper, .monthly_expenses .field-input_wrapper {
 	&::before {
 		content: "$";
 		width: 1em;
@@ -177,6 +177,26 @@ button[type="submit"].action-back { .btn-default; .btn-lg; }
 	}
 	&::after {
 		content: ".00 / month";
+		width: 1em;
+		font-size: 1.25em;
+		padding: .25em .5em .25em 0;
+		font-weight: 400;
+	}
+	input {
+		text-align: right;
+	}
+}
+
+.how_much_savings .field-input_wrapper {
+	&::before {
+		content: "$";
+		width: 1em;
+		font-size: 1.25em;
+		padding: .25em 0;
+		font-weight: 400;
+	}
+	&::after {
+		content: ".00";
 		width: 1em;
 		font-size: 1.25em;
 		padding: .25em .5em .25em 0;

--- a/user_accounts/fixtures/organizations.json
+++ b/user_accounts/fixtures/organizations.json
@@ -441,7 +441,7 @@
     "is_receiving_agency": true,
     "is_accepting_applications": true,
     "is_checking_notifications": true,
-    "is_live": false,
+    "is_live": true,
     "requires_rap_sheet": false,
     "requires_declaration_letter": false,
     "show_pdf_only": false,


### PR DESCRIPTION
Prepare Santa Barbara for go-live. 

Small edit: during UAT of the SB form, I caught that the "savings" question input had a `/month` after it (reuse of similar CSS from income/expenses questions). Since this does not make sense, I resolved that here as well.