### PR TITLE
Revert "Regenerate fake data on release to cmr-demo & cmr-develop"

### DIFF
--- a/intake/management/commands/heroku_release.py
+++ b/intake/management/commands/heroku_release.py
@@ -1,6 +1,5 @@
 from django.core import management
 from django.core.management.base import BaseCommand
-from django.conf import settings
 
 
 class Command(BaseCommand):
@@ -9,7 +8,4 @@ class Command(BaseCommand):
 
     def handle(self, *args, **kwargs):
         management.call_command('migrate')
-        if getattr(settings, 'GENERATE_DUMMY_DATA', False):
-            management.call_command('new_fixtures')
-        else:
-            management.call_command('load_essential_data')
+        management.call_command('load_essential_data')


### PR DESCRIPTION
Reverts codeforamerica/intake#890.

Upon discussion, we are rolling this back and opting to do new fixture commands manually for the moment.