### PR TITLE
Temporary deactivation for Ventura

### DIFF
--- a/intake/constants.py
+++ b/intake/constants.py
@@ -217,11 +217,7 @@ COUNTY_CHOICES = (
             'Sebastopol, Bodega Bay, Healdsburg, or Cloverdale)')),
     (Counties.SANTA_BARBARA, _(
         'Santa Barbara County (near Santa Maria, Santa Barbara, Goleta, '
-        'Carpinteria, Solvang, and Lompoc)')),
-    (Counties.VENTURA, _(
-            'Ventura County (near Oxnard, Thousand Oaks, Simi Valley, '
-            'Camarillo, Ojai, Moorpark, Fillmore, Santa Paula, or '
-            'Ventura)')),
+        'Carpinteria, Solvang, and Lompoc)'))
 )
 
 if SCOPE_TO_LIVE_COUNTIES and len(COUNTY_CHOICES) == 3:
@@ -242,6 +238,10 @@ if not SCOPE_TO_LIVE_COUNTIES:
         (Counties.YOLO, _(
             'Yolo County (near Davis, West Sacramento, Winters, and '
             'Woodland)')),
+        (Counties.VENTURA, _(
+            'Ventura County (near Oxnard, Thousand Oaks, Simi Valley, '
+            'Camarillo, Ojai, Moorpark, Fillmore, Santa Paula, or '
+            'Ventura)')),
     )
 
 COUNTY_CHOICES = sorted(COUNTY_CHOICES, key=lambda item: item[1])

--- a/templates/includes/county-seals.jinja
+++ b/templates/includes/county-seals.jinja
@@ -12,8 +12,8 @@
     <p class="text--small">Alameda</p>
   </li>
   <li class="county-seal">
-    <div class="illustration illustration--ventura"></div>
-    <p class="text--small">Ventura</p>
+    <div class="illustration illustration--solano"></div>
+    <p class="text--small">Solano</p>
   </li>
   <li class="county-seal">
     <div class="illustration illustration--contra-costa"></div>

--- a/user_accounts/fixtures/organizations.json
+++ b/user_accounts/fixtures/organizations.json
@@ -412,7 +412,7 @@
     "is_receiving_agency": true,
     "is_accepting_applications": true,
     "is_checking_notifications": true,
-    "is_live": true,
+    "is_live": false,
     "requires_rap_sheet": false,
     "requires_declaration_letter": false,
     "show_pdf_only": false,


### PR DESCRIPTION
Closes #958.

Temporarily removing Ventura from live county choices on production. The organization and existing records will still exist, but the county will not be offered as a choice in the application form / displayed on the partner page until Ventura requests a reactivation.