### PR TITLE
remove intercom code from CMR

### DIFF
--- a/templates/includes/intercom.jinja
+++ b/templates/includes/intercom.jinja
@@ -1,7 +1,0 @@
-<!-- Intercom chat support -->
-<script>
-  window.intercomSettings = {
-    app_id: "bey83rgj"
-  };
-</script>
-<script>(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/bey83rgj';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()</script>

--- a/templates/public_base.jinja
+++ b/templates/public_base.jinja
@@ -42,7 +42,6 @@
   {% block jsons %}{% endblock jsons %}
   {% include "includes/google_analytics.jinja" %}
   {% include "includes/mixpanel.jinja" %}
-  {% include "includes/intercom.jinja" %}
   {% block main_script %}
   {% endblock main_script %}
 {% endblock scripts %}


### PR DESCRIPTION
This branch removes the intercom include template (with the script that brings in the live chat modal) and the reference to that include.

This does not deactivate the CMR Intercom account; this is a separate, second step after this has been deployed, to prevent loss of customer support items.

Closes #965 