### PR TITLE
Template and styling updates

### DIFF
--- a/intake/static/intake/less/admin.less
+++ b/intake/static/intake/less/admin.less
@@ -184,10 +184,11 @@ ul.tags-autocomplete_results, ul.applications-autocomplete_results {
 	border-style: solid;
 	border-width: 2px;
 	border-bottom: none;
+	margin-right: 5px;
 	a {
 		color: #bbbbbb;
 		display: inline-block;
-		padding: 1em;
+		padding: 12px;
 	}
 }
 
@@ -213,7 +214,7 @@ ul.tags-autocomplete_results, ul.applications-autocomplete_results {
 }
 
 .app-index-title {
-	padding: 1em;
+	padding: 50px 1em 1em;
 	h1 {
 		display: inline;
 	}
@@ -302,6 +303,7 @@ li.application-event-block{
 /***Autocomplete (App Index)***/
 .vertical-padded{
   padding: 1em 0;
+  margin-top: 15px;
 }
 
 .followups-search_module, .applications-search_module {

--- a/intake/static/intake/less/admin.less
+++ b/intake/static/intake/less/admin.less
@@ -223,6 +223,10 @@ ul.tags-autocomplete_results, ul.applications-autocomplete_results {
 	}
 }
 
+.no-results {
+	padding: 1em;
+}
+
 .update-status-button {
 	position: absolute;
 	right: 0;

--- a/intake/static/intake/less/custom.less
+++ b/intake/static/intake/less/custom.less
@@ -327,6 +327,10 @@ section.footer.container.new_section{
   text-align: center;
 }
 
+.no-footer {
+  padding-bottom: 100px;
+}
+
 
 ul.opportunities {
   padding-top: 12px;

--- a/intake/tests/mock.py
+++ b/intake/tests/mock.py
@@ -332,25 +332,34 @@ def build_seed_submissions():
         organizations=target_orgs)
     subs.append(multi_org_sub)
     sub_ids = [sub.id for sub in subs]
-    applications = models.Application.objects.filter(
-        form_submission_id__in=sub_ids)
+    # applications = models.Application.objects.filter(
+    #     form_submission_id__in=sub_ids)
 
     applicants = []
     for sub in subs:
         applicants.append(sub.applicant)
 
-    for application in applications:
+    """
+    Creating status updates for all applications forces a mock situation
+    in which there are 0 unread applications, which limits our test range.
+    Working around that by only doing so for the first 2 applications to
+    an org.
+    """
+    for org in orgs:
+        updated_application = models.Application.objects.filter(
+            organization=org, form_submission_id__in=sub_ids).first()
         factories.StatusUpdateWithNotificationFactory.create(
-            application=application,
-            author=application.organization.profiles.first().user)
-        application.has_been_opened = True
-        application.save()
+            application=updated_application,
+            author=org.profiles.first().user)
+        updated_application.has_been_opened = True
+        updated_application.save()
 
     for org in orgs:
         org_subs = []
         for sub in subs:
-            has_app = sub.applications.filter(organization=org).exists()
-            if has_app and sub != multi_org_sub:
+            has_unread_app = sub.applications.filter(
+                organization=org, has_been_opened=False).exists()
+            if has_unread_app and sub != multi_org_sub:
                 org_subs.append(sub)
         # make a bundle for each org
         bundle = BundlesService.create_bundle_from_submissions(

--- a/intake/tests/mock.py
+++ b/intake/tests/mock.py
@@ -357,9 +357,8 @@ def build_seed_submissions():
     for org in orgs:
         org_subs = []
         for sub in subs:
-            has_unread_app = sub.applications.filter(
-                organization=org, has_been_opened=False).exists()
-            if has_unread_app and sub != multi_org_sub:
+            has_app = sub.applications.filter(organization=org).exists()
+            if has_app and sub != multi_org_sub:
                 org_subs.append(sub)
         # make a bundle for each org
         bundle = BundlesService.create_bundle_from_submissions(

--- a/intake/tests/mock.py
+++ b/intake/tests/mock.py
@@ -343,6 +343,8 @@ def build_seed_submissions():
         factories.StatusUpdateWithNotificationFactory.create(
             application=application,
             author=application.organization.profiles.first().user)
+        application.has_been_opened = True
+        application.save()
 
     for org in orgs:
         org_subs = []

--- a/intake/tests/views/test_admin_views.py
+++ b/intake/tests/views/test_admin_views.py
@@ -306,9 +306,14 @@ class TestApplicationIndex(IntakeDataTestCase):
         user = self.be_apubdef_user()
         response = self.client.get(reverse('intake-app_all_index'))
         for sub in self.a_pubdef_submissions:
-            status = sub.applications.filter(
+
+            status_update = sub.applications.filter(
                 organization=user.profile.organization).first(
-            ).status_updates.latest('updated').status_type.display_name
+            ).status_updates.order_by('-updated').first()
+            if status_update:
+                status = status_update.status_type.display_name
+            else:
+                status = 'Unread'
             self.assertContains(
                 response, html_utils.conditional_escape(status))
 

--- a/intake/views/admin_views.py
+++ b/intake/views/admin_views.py
@@ -119,6 +119,8 @@ class ApplicationIndex(ViewAppDetailsMixin, TemplateView):
                 self.request.user.profile.organization, 'All')
             context['app_index_scope_title'] = "All Applications To {}".format(
                 self.request.user.profile.organization.name)
+            if count == 0:
+                context['no_results'] = "You have no applications."
         context['page_counter'] = \
             utils.get_page_navigation_counter(
                 page=context['results'],
@@ -138,6 +140,7 @@ class ApplicationUnreadIndex(ApplicationIndex):
             count)
         if count == 0:
             context['print_all_link'] = None
+            context['no_results'] = "You have read all new applications!"
         else:
             context['print_all_link'] = get_url_for_ids(
                 'intake-pdf_bundle_wrapper_view',
@@ -163,6 +166,10 @@ class ApplicationNeedsUpdateIndex(ApplicationUnreadIndex):
         context['app_index_tabs'], count = get_tabs_for_org_user(
             self.request.user.profile.organization,
             'Needs Status Update')
+        if count == 0:
+            context['no_results'] = "You have updated all applications!"
+        else:
+            context['no_results'] = None
         context['print_all_link'] = None
         context['app_index_scope_title'] = \
             "{} Applications Need Status Updates".format(count)

--- a/templates/app_index.jinja
+++ b/templates/app_index.jinja
@@ -36,8 +36,8 @@
   {% include "includes/results_paginator.jinja" %}
   {%- endif %}
 </div>
+<div class="no-footer"></div>
 {% endblock content %}
-
 
 {% block scripts %}
 {%- if ALL_TAG_NAMES %}

--- a/templates/app_reviewer_list.jinja
+++ b/templates/app_reviewer_list.jinja
@@ -1,5 +1,5 @@
 {%- if no_results %}
-  <p>{{ no_results }}</p>
+  <p class="no-results">{{ no_results }}</p>
 {%- else %}
   <table class="table applications_list">
   <tr>

--- a/templates/app_reviewer_list.jinja
+++ b/templates/app_reviewer_list.jinja
@@ -1,22 +1,25 @@
-<table class="table applications_list">
-<tr>
-  <th>Date</th>
-  <th>Last Name</th>
-  <th>First Name</th>
-  {%- if show_pdf %}
-  <th>Intake PDF</th>
-  {%- endif %}
-  <th>Status</th>
-  <th>Latest Status Update</th>
-  <th>Actions</th>
-  <th></th>
-</tr>
-{%- for app in results %}
-  {%- if app.was_transferred_out %}
-    {%- include "includes/org_user_transferred_app_listing.jinja" %}
-  {%- else %}
-    {%- include "includes/org_user_app_index_listing.jinja" %}
-  {%- endif %}
-{%- endfor %}
-  
-</table>
+{%- if no_results %}
+  <p>{{ no_results }}</p>
+{%- else %}
+  <table class="table applications_list">
+  <tr>
+    <th>Date</th>
+    <th>Last Name</th>
+    <th>First Name</th>
+    {%- if show_pdf %}
+    <th>Intake PDF</th>
+    {%- endif %}
+    <th>Status</th>
+    <th>Latest Status Update</th>
+    <th>Actions</th>
+    <th></th>
+  </tr>
+  {%- for app in results %}
+    {%- if app.was_transferred_out %}
+      {%- include "includes/org_user_transferred_app_listing.jinja" %}
+    {%- else %}
+      {%- include "includes/org_user_app_index_listing.jinja" %}
+    {%- endif %}
+  {%- endfor %}
+  </table>
+{%- endif %}


### PR DESCRIPTION
Based on findings during UAT:

-  padding in tabs reduced to 12px
- margin between tabs set to 5px
- upper margin between search bar and top bar of 15px
- 100px padding set between bottom of table / bottom of page when no footer present (app index view, etc)
- fallback text displayed when no new/needs-update applications in a tab (& indent/pad same amount as table)
- update mocks -- apps with status updates should be marked read / remove reliance on mock fixtures for some tests
