### PR TITLE
Prevent submit on enter keypress in search widget

### DIFF
--- a/intake/static/intake/js/search_widget.js
+++ b/intake/static/intake/js/search_widget.js
@@ -23,15 +23,20 @@ function initializeSearchWidget(inputSelector, postURL, resultsCallback, emptySe
   }
 
 
-  function handleKeyupInSearchInput(e){
+  function handleKeypressInSearchInput(e){
     var searchTerm = $(this).val();
+
+    if (event.which == 13 || event.keyCode == 13) {
+        //detects an enter keypress, false return prevents form submit
+        return false;
+    }
     if (searchTerm.length > 0){
       sendSearchQuery(searchTerm);
     } else {
       emptySearchCallback();
     }
   }
-  $(inputSelector).on('keyup', "input[name='q']", handleKeyupInSearchInput);
+  $(inputSelector).on('keypress', "input[name='q']", handleKeypressInSearchInput);
 }
 
 module.exports = initializeSearchWidget;

--- a/intake/static/intake/js/search_widget.js
+++ b/intake/static/intake/js/search_widget.js
@@ -23,20 +23,16 @@ function initializeSearchWidget(inputSelector, postURL, resultsCallback, emptySe
   }
 
 
-  function handleKeypressInSearchInput(e){
+  function handleKeyupInSearchInput(e){
     var searchTerm = $(this).val();
 
-    if (event.which == 13 || event.keyCode == 13) {
-        //detects an enter keypress, false return prevents form submit
-        return false;
-    }
     if (searchTerm.length > 0){
       sendSearchQuery(searchTerm);
     } else {
       emptySearchCallback();
     }
   }
-  $(inputSelector).on('keypress', "input[name='q']", handleKeypressInSearchInput);
+  $(inputSelector).on('keyup', "input[name='q']", handleKeyupInSearchInput);
 }
 
 module.exports = initializeSearchWidget;

--- a/templates/app_index.jinja
+++ b/templates/app_index.jinja
@@ -7,15 +7,11 @@
     <div class="col-xs-12">
       {% if user.groups.filter(name='followup_staff').exists() %}
         <div class="followups-search_module">
-          <form>
             <input name="q" placeholder="Search all applications" type="text" autocomplete="off">
-          </form>
         </div>
       {% else %}
         <div class="applications-search_module">
-          <form>
             <input name="q" placeholder="Search all applications" type="text" autocomplete="off"><ul class="applications-autocomplete_results"></ul>
-          </form>
         </div>
       {% endif %}
     </div>


### PR DESCRIPTION
Closes #981 

Swapping out `keypress` for `keyup` gives us a little more flexibility here, we can detect the `enter` key (13) and return `false` to prevent an action when enter is pressed. This allows us to keep most of the search widget code intact while resolving the bug that navigated to the postURL on enter/submit.

Pressing any other key will cause the widget to operate as it has been.