### PR TITLE
Yolo form updates

### DIFF
--- a/formation/fields.py
+++ b/formation/fields.py
@@ -123,6 +123,19 @@ class IdentityConfirmation(ConsentCheckbox):
         "Confirms application is for self or with permission")
 
 
+class UnderstandsMaybeFee(ConsentCheckbox):
+    context_key = "understands_maybe_fee"
+    is_required_error_message = (
+        "We need your understanding before we can help you")
+    label = _(
+        "Do you understand that if you are eligible, you might have to pay a "
+        "fee in Yolo County? If you are low income, you may be eligible for "
+        "a fee waiver.")
+    agreement_text = _("Yes, I understand")
+    display_label = str(
+        "Understands that there may be a fee in Yolo County")
+
+
 class ReasonsForApplying(MultipleChoiceField):
     context_key = "reasons_for_applying"
     label = _("Why are you applying to clear your record?")
@@ -701,6 +714,7 @@ INTAKE_FIELDS = [
     AdditionalInformation,
     UnderstandsLimits,
     IdentityConfirmation,
+    UnderstandsMaybeFee,
     ConsentToRepresent,
     ConsentNote,
 

--- a/formation/forms.py
+++ b/formation/forms.py
@@ -563,8 +563,6 @@ class YoloCountyFormSpec(SonomaCountyFormSpec):
     county = Counties.YOLO
     fields = (SonomaCountyFormSpec.fields | {
         F.Aliases,
-        F.DriverLicenseOrIDNumber,
-        F.LastFourOfSocial,
         F.CaseNumber,
         F.CurrentlyEmployed,
         F.MonthlyIncome,
@@ -575,10 +573,13 @@ class YoloCountyFormSpec(SonomaCountyFormSpec):
         F.OwnsHome,
         F.HasChildren,
         F.HowManyDependents,
-        F.IsMarried
+        F.IsMarried,
+        F.UnderstandsMaybeFee
     }) - {
         F.AlternatePhoneNumberField,
-        F.OwesCourtFees
+        F.OwesCourtFees,
+        F.ServingSentence,
+        F.USCitizen
     }
     required_fields = (SonomaCountyFormSpec.required_fields | {
         F.CurrentlyEmployed,
@@ -589,7 +590,8 @@ class YoloCountyFormSpec(SonomaCountyFormSpec):
         F.OwnsHome,
         F.HowManyDependents,
         F.IsMarried,
-        F.ReasonsForApplying
+        F.ReasonsForApplying,
+        F.UnderstandsMaybeFee
         }) - {
         F.OwesCourtFees,
     }

--- a/formation/templates/formation/intake_display.jinja
+++ b/formation/templates/formation/intake_display.jinja
@@ -77,7 +77,7 @@
     </div>
     {%- endif %}
     <div class="data_display-stack">
-      {{ form.serving_sentence }}
+      {{ form.serving_sentence_display }}
     </div>
     {%- if 'rap_outside_sf' in form.fields %}
     <div class="data_display-stack external_rap">
@@ -132,6 +132,9 @@
     </div>
     <div class="data_display-row">
       {{ form.identity_confirmation_display }}
+    </div>
+    <div class="data_display-row">
+      {{ form.understands_maybe_fee_display }}
     </div>
     <div class="data_display-row">
       {{ form.how_did_you_hear }}

--- a/intake/tests/mock_county_forms/__init__.py
+++ b/intake/tests/mock_county_forms/__init__.py
@@ -344,6 +344,7 @@ class Provider(BaseProvider):
             has_children=self.maybe(0.4),
             dependents=random.randint(0, 4),
             currently_employed=self.maybe(0.4),
+            understands_maybe_fee='yes'
             )
         return data
 

--- a/printing/pdf_form_display.py
+++ b/printing/pdf_form_display.py
@@ -72,9 +72,14 @@ class PDFFormDisplay:
         ['household_size', 'dependents', 'has_children', 'is_married'],
         ['owns_home', 'on_public_benefits'],
         ['how_did_you_hear'],
-        ['understands_limits'],
-        ['consent_to_represent'],
-        ['identity_confirmation'],
+        [
+            'understands_limits',
+            'consent_to_represent'
+        ],
+        [
+            'identity_confirmation',
+            'understands_maybe_fee'
+        ],
         ['additional_information'],
     ]
 


### PR DESCRIPTION
Closes #975 

Included in this branch:
* New question (understands that there may be a fee, required consent checkbox) added to Yolo form
* New question added to display templates for Yolo and mock answers
* Some questions removed from Yolo form (per ticket / questions spreadsheet)
* Fix display issue on "serving sentence" question in intake display (was erroring when absent)
* Move some of the questions into same-row on pdf display (mostly consent checkboxes, they were running into the end of the page when in a single-column format)