### PR TITLE
zero pad the week of the year keys so data from the the first 9 weeks…

### DIFF
--- a/intake/services/statistics.py
+++ b/intake/services/statistics.py
@@ -105,8 +105,8 @@ def get_org_data_dict():
     for row in org_app_data:
         current_org_app_data_by_week = org_app_data_by_week.setdefault(
             row['organization_id'], {})
-        current_org_app_data_by_week['%d-%02d-1' % (row['yr'], row['wk'])] = row[
-            'fs_count']
+        current_org_app_data_by_week['%d-%02d-1' % (row['yr'], row['wk'])] = \
+            row['fs_count']
 
     # Transform the org-specific data into something formatted for charting
     # purposes with the grand total and weekly time-series data and add it to

--- a/intake/services/statistics.py
+++ b/intake/services/statistics.py
@@ -80,7 +80,7 @@ def get_org_data_dict():
     # Convert the db results to a dict keyed by the week of the year in
     # datetime format. The '-1' at the end indicates weeks starting on Mondays.
     total_app_data_by_week = {
-        '%d-%d-1' % (row['yr'], row['wk']): row['fs_count'] for row in
+        '%d-%02d-1' % (row['yr'], row['wk']): row['fs_count'] for row in
         total_app_data}
 
     # Transform the totals data into something formatted for charting purposes
@@ -105,7 +105,7 @@ def get_org_data_dict():
     for row in org_app_data:
         current_org_app_data_by_week = org_app_data_by_week.setdefault(
             row['organization_id'], {})
-        current_org_app_data_by_week['%d-%d-1' % (row['yr'], row['wk'])] = row[
+        current_org_app_data_by_week['%d-%02d-1' % (row['yr'], row['wk'])] = row[
             'fs_count']
 
     # Transform the org-specific data into something formatted for charting


### PR DESCRIPTION
… of the year renders properly

Closes #888 

### What does this do and why?

My original change has been merged but with staging data it was clear there's a bug I didn't catch in dev. Turns out it had to do with the data dictionary keys for the first 9 weeks of the year not having a leading 0 e.g. 2017-01-1 is the right key for the first week of the year, not 2017-1-1

### Testing & Checks

Validate manually on staging.
