### PR TITLE
template changes to allow display of invalid legacy phone numbers

### DIFF
--- a/formation/templates/formation/phone_display.jinja
+++ b/formation/templates/formation/phone_display.jinja
@@ -1,10 +1,15 @@
 <div class="data_display {% if field.is_subfield %}sub{% endif %}datum {{ field.get_html_class_name() }}">
   <div class="data_display-label">{{ field.get_display_label() }}</div>
-  {%- if not field.is_empty() %}
+  {%- set display_value = field.get_display_value() %}
+  {%- if display_value %}
   <div class="data_display-value">
-    <a href="tel:{{ field.get_tel_href_number() }}" class="data_display-link">
-      {{- field.get_display_value() -}}
-     </a>
+    {%- if field.get_current_value_parsed() %}
+      <a href="tel:{{ field.get_tel_href_number() }}" class="data_display-link">
+        {{- display_value -}}
+       </a>
+    {%- else %}
+      <span class="data_display-link">{{- display_value -}}</span>
+    {%- endif %}
   </div>
   {%- else %}
   <div class="data_display-value empty"></div>


### PR DESCRIPTION
Closes remaining issues from #1103 

### What does this do and why?

After reviewing the previous changes in staging from https://github.com/codeforamerica/intake/pull/1104, it appears that the display of invalid legacy numbers did not work as hoped. This resolves that discrepancy.

Review https://github.com/codeforamerica/intake/pull/1104 for full details.