### PR TITLE
made git requirements update on heroku

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+src
 __pycache__
 *.pyc
 *.swp

--- a/requirements/app.txt
+++ b/requirements/app.txt
@@ -8,7 +8,7 @@ python-dateutil~=2.5
 phonenumbers==8.8.0
 django-storages~=1.5
 django-allauth==0.32
-https://github.com/bee-keeper/django-invitations/archive/master.tar.gz
+-e git+git://github.com/bee-keeper/django-invitations@master#egg=django-invitations
 sendgrid-django~=2.0
 django-jinja~=2.2
 django-debug-toolbar==1.4
@@ -27,8 +27,7 @@ amqp==2.1.4
 PyYAML==3.12
 user-agents==1.1.0
 ua-parser==0.7.3
-https://github.com/rossettistone/django-easy-audit/archive/patched.tar.gz
-
+-e git+git://github.com/rossettistone/django-easy-audit.git@patched#egg=django-easy-audit
 # factory-boy breaks on later version fo fake-factory
 # we need to pin fake-factory
 fake-factory==0.7.2


### PR DESCRIPTION
by making the git requirements editable heroku will now update them
this adds a src directory to the project on install which is now
gitignored

Closes #1143

### What does this do and why?

This makes git repos update on each install so that easyaudit will receive changes as we make them.

### Testing & Checks

What does this PR include?
- [x] new dependencies
- [ ] migrations
- [ ] data migrations
- [ ] celery tasks
- [ ] changes to environment variables or local settings
- [x] configuration changes for 3rd party services (Travis, Heroku, AWS, Github, etc) 
- [ ] visual or style changes

Are there any human checks that should be used to verify these changes, such as user acceptance tests (UAT) or manual deployment checks?

It shouldn't say we need to make migrations on develop or other places and run the 0006 easy audit migraiton.
