### PR TITLE
Switch on Stanislaus

### DIFF
--- a/user_accounts/fixtures/organizations.json
+++ b/user_accounts/fixtures/organizations.json
@@ -501,7 +501,7 @@
     "is_receiving_agency": true,
     "is_accepting_applications": true,
     "is_checking_notifications": true,
-    "is_live": false,
+    "is_live": true,
     "requires_rap_sheet": false,
     "requires_declaration_letter": false,
     "show_pdf_only": false,


### PR DESCRIPTION
This modifies our `organizations.json` fixture to add Stanislaus to the list of live counties.