### PR TITLE
permit 'unknown' email verification

### DIFF
--- a/intake/services/contact_info_validation_service.py
+++ b/intake/services/contact_info_validation_service.py
@@ -35,6 +35,7 @@ def validate_email_with_mailgun(email):
             'Mailgun returned {} {}'.format(
                 status_code, parsed_response))
     is_valid = parsed_response['is_valid']
-    mailbox_exists = parsed_response['mailbox_verification'] == 'true'
+    # possible return values are 'false', 'unknown', and 'true'
+    mailbox_might_exist = parsed_response['mailbox_verification'] != 'false'
     suggestion = parsed_response.get('did_you_mean', None)
-    return (is_valid and mailbox_exists, suggestion)
+    return (is_valid and mailbox_might_exist, suggestion)

--- a/intake/tests/services/test_contact_info_validation_service.py
+++ b/intake/tests/services/test_contact_info_validation_service.py
@@ -138,12 +138,34 @@ class TestValidateEmailWithMailgun(TestCase):
                 'is_disposable_address': False,
                 'is_role_address': False,
                 'is_valid': False,
-                'mailbox_verification': 'unknown',
+                'mailbox_verification': 'false',
                 'parts': {
                     'display_name': None,
                     'domain': None,
                     'local_part': None}})
         expected_response = (False, None)
+        self.assertEqual(
+            expected_response,
+            validate_email_with_mailgun(email))
+
+    @patch(
+        'intake.services.contact_info_validation_service.mailgun_get_request')
+    def test_valid_email_with_unknown_confirmation(self, mock_mailgun_get):
+        email = 'ovinsbf'
+        mock_mailgun_get.return_value = (
+            200,
+            {
+                'address': 'something@yahoo.com',
+                'did_you_mean': None,
+                'is_disposable_address': False,
+                'is_role_address': False,
+                'is_valid': True,
+                'mailbox_verification': 'unknown',
+                'parts': {
+                    'display_name': None,
+                    'domain': None,
+                    'local_part': None}})
+        expected_response = (True, None)
         self.assertEqual(
             expected_response,
             validate_email_with_mailgun(email))


### PR DESCRIPTION
Closes #1229 

### What does this do and why?

Mailgun will tell us whether or not an email is verified with three possible answers: `true`, `false`, and `unknown`. This treats emails marked with `unknown` verification as an acceptable answer, because applicants with working email addresses (`@yahoo.com`) were being blocked.

### Testing & Checks

What does this PR include?
- [ ] new dependencies
- [ ] migrations
- [ ] data migrations
- [ ] celery tasks
- [ ] changes to environment variables or local settings
- [ ] configuration changes for 3rd party services (Travis, Heroku, AWS, Github, etc) 
- [ ] visual or style changes

_Any integration or unit tests?_

This adds one unit test to ensure `unknown` email verifications are handled correctly.
