### PR TITLE
Release: Oct 9, 2017 - Fixes for email validation

### DIFF
--- a/formation/base.py
+++ b/formation/base.py
@@ -29,7 +29,8 @@ class BindParseValidate(Renderable):
     # context_key is used for scoping errors
     context_key = DEFAULT_CONTEXT_KEY
 
-    def __init__(self, data=UNSET, initial=None, prefix=None):
+    def __init__(self, data=UNSET, initial=None, prefix=None,
+                 skip_validation_parse_only=False):
         """`raw_input_data` is expected to be a `dict` or `MultiValueDict`
         By default it is `UNSET`.
         """
@@ -39,6 +40,7 @@ class BindParseValidate(Renderable):
         self.errors = {}
         self.warnings = {}
         self.initial_data = initial
+        self.skip_validation_parse_only = skip_validation_parse_only
         if prefix:
             self.context_key = prefix + self.context_key
 
@@ -76,7 +78,8 @@ class BindParseValidate(Renderable):
 
     def parse_and_validate(self, raw_data):
         self.parsed_data = self.parse(raw_data)
-        self.validate()
+        if not self.skip_validation_parse_only:
+            self.validate()
 
     def parse(self, raw_data):
         """The default parsing operation does

--- a/formation/display_form_base.py
+++ b/formation/display_form_base.py
@@ -5,12 +5,15 @@ class DisplayForm(Form):
     """Used to display a set of fields, not for input
     """
 
-    def __init__(self, *args, validate=True, **kwargs):
+    def __init__(self, *args, validate=True, skip_validation_parse_only=True,
+                 **kwargs):
         """setting display_only to True means that
         calls to .render() will render display versions
         by default.
         """
-        super().__init__(*args, validate=validate, **kwargs)
+        super().__init__(
+            *args, validate=validate,
+            skip_validation_parse_only=skip_validation_parse_only, **kwargs)
         self.display_only = True
 
     def build_field(self, field_class):

--- a/formation/form_base.py
+++ b/formation/form_base.py
@@ -14,7 +14,8 @@ class Form(base.BindParseValidate):
         'optional_fields'
     ]
 
-    def __init__(self, *args, files=None, validate=False, **kwargs):
+    def __init__(self, *args, files=None, validate=False,
+                 skip_validation=False, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields = OrderedDict([
             (field_class.context_key, self.build_field(field_class))
@@ -92,7 +93,10 @@ class Form(base.BindParseValidate):
         init_args = []
         if self.raw_input_data is not base.UNSET:
             init_args.append(self.raw_input_data)
-        field = field_class(*init_args, **init_kwargs)
+        field = field_class(
+            *init_args,
+            skip_validation_parse_only=self.skip_validation_parse_only,
+            **init_kwargs)
         # this might error if a context_key is not a valid
         # python variable name or if the field is named after
         # an attribute on this object

--- a/formation/tests/test_base.py
+++ b/formation/tests/test_base.py
@@ -121,3 +121,15 @@ class TestBindParseValidate(TestCase):
             context_key = "bar"
         unbound = Scoped(prefix="foo")
         self.assertEqual(unbound.context_key, "foobar")
+
+    def test_wont_run_validators_if_skip_validation_parse_only(self):
+        input_data = {}
+        validator = Mock()
+
+        class MyForm(base.BindParseValidate):
+            validators = [validator]
+
+        form = MyForm(input_data, skip_validation_parse_only=True)
+        self.assertEqual(form.is_valid(), True)
+        self.assertDictEqual(form.errors, {})
+        validator.assert_not_called()

--- a/formation/tests/test_display_form_base.py
+++ b/formation/tests/test_display_form_base.py
@@ -1,0 +1,26 @@
+from unittest.mock import Mock
+from django.test import TestCase
+
+from formation.display_form_base import DisplayForm
+from formation.field_types import IntegerField
+
+
+class NumberField(IntegerField):
+    context_key = 'number'
+
+
+class ExampleDisplayForm(DisplayForm):
+    fields = [NumberField]
+
+
+class TestDisplayForm(TestCase):
+
+    def test_sets_self_and_fields_as_dislay_only(self):
+        form = ExampleDisplayForm(dict(number=25))
+        self.assertTrue(form.display_only)
+        self.assertTrue(form.number.display_only)
+
+    def test_defaults_to_parse_only(self):
+        form = ExampleDisplayForm(dict(number=25))
+        self.assertTrue(form.skip_validation_parse_only)
+        self.assertTrue(form.number.skip_validation_parse_only)

--- a/formation/tests/test_form_base.py
+++ b/formation/tests/test_form_base.py
@@ -1,8 +1,10 @@
+from unittest.mock import Mock
 from django.test import TestCase
 from formation.tests import mock
 
 from formation.forms import county_form_selector
 from formation import fields as F
+from formation.field_types import IntegerField
 from formation.field_base import Field
 from formation.form_base import Form
 from formation import validators
@@ -192,3 +194,22 @@ class TestForm(TestCase):
         form = self.get_sf_form(fake_answers)
         with self.assertRaises(AttributeError):
             str(form.foobar)
+
+    def test_fields_inherit_skip_validation_parse_only(self):
+        field_validator = Mock()
+        form_validator = Mock()
+
+        class SmallNumberField(IntegerField):
+            context_key = 'number'
+            validators = [field_validator]
+
+        class ExampleForm(Form):
+            fields = [SmallNumberField]
+            validators = [form_validator]
+
+        form = ExampleForm(
+            dict(number='11'), skip_validation_parse_only=True)
+        self.assertTrue(form.is_valid())
+        self.assertEqual(11, form.cleaned_data['number'])
+        field_validator.assert_not_called()
+        form_validator.assert_not_called()

--- a/intake/services/contact_info_validation_service.py
+++ b/intake/services/contact_info_validation_service.py
@@ -35,6 +35,7 @@ def validate_email_with_mailgun(email):
             'Mailgun returned {} {}'.format(
                 status_code, parsed_response))
     is_valid = parsed_response['is_valid']
-    mailbox_exists = parsed_response['mailbox_verification'] == 'true'
+    # possible return values are 'false', 'unknown', and 'true'
+    mailbox_might_exist = parsed_response['mailbox_verification'] != 'false'
     suggestion = parsed_response.get('did_you_mean', None)
-    return (is_valid and mailbox_exists, suggestion)
+    return (is_valid and mailbox_might_exist, suggestion)

--- a/intake/tests/mock_org_answers.py
+++ b/intake/tests/mock_org_answers.py
@@ -17,7 +17,9 @@ class AnswerGenerator:
         for mock_method_name, form_class in \
                 self.mock_method_form_class_pairs.items():
             raw_answers = getattr(fake, mock_method_name)()
-            form = form_class(raw_answers, validate=True)
+            # don't acutally validate, just parse. We are generating seed data
+            form = form_class(
+                raw_answers, validate=True, skip_validation_parse_only=True)
             cleaned_data.update(form.cleaned_data)
         return cleaned_data
 

--- a/intake/tests/serializers/test_fields.py
+++ b/intake/tests/serializers/test_fields.py
@@ -50,8 +50,7 @@ class TestContactInfoByPreferenceField(TestCase):
         expected_output = [
             ('email', 'test@gmail.com'),
         ]
-        results = ContactInfoByPreferenceField(
-        ).to_representation(answers)
+        results = ContactInfoByPreferenceField().to_representation(answers)
         self.assertEqual(results, expected_output)
 
     def test_empty_input_returns_empty_list(self):

--- a/intake/tests/services/test_contact_info_validation_service.py
+++ b/intake/tests/services/test_contact_info_validation_service.py
@@ -138,12 +138,34 @@ class TestValidateEmailWithMailgun(TestCase):
                 'is_disposable_address': False,
                 'is_role_address': False,
                 'is_valid': False,
-                'mailbox_verification': 'unknown',
+                'mailbox_verification': 'false',
                 'parts': {
                     'display_name': None,
                     'domain': None,
                     'local_part': None}})
         expected_response = (False, None)
+        self.assertEqual(
+            expected_response,
+            validate_email_with_mailgun(email))
+
+    @patch(
+        'intake.services.contact_info_validation_service.mailgun_get_request')
+    def test_valid_email_with_unknown_confirmation(self, mock_mailgun_get):
+        email = 'ovinsbf'
+        mock_mailgun_get.return_value = (
+            200,
+            {
+                'address': 'something@yahoo.com',
+                'did_you_mean': None,
+                'is_disposable_address': False,
+                'is_role_address': False,
+                'is_valid': True,
+                'mailbox_verification': 'unknown',
+                'parts': {
+                    'display_name': None,
+                    'domain': None,
+                    'local_part': None}})
+        expected_response = (True, None)
         self.assertEqual(
             expected_response,
             validate_email_with_mailgun(email))

--- a/intake/tests/test_not_validating_too_much.py
+++ b/intake/tests/test_not_validating_too_much.py
@@ -1,0 +1,29 @@
+from unittest.mock import patch
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from django.conf import settings
+from user_accounts.models import Organization
+from intake.tests.factories import FormSubmissionWithOrgsFactory, make_apps_for
+from user_accounts.tests.factories import app_reviewer
+
+
+class TestDontValidateTooMuch(TestCase):
+    fixtures = ['counties', 'organizations']
+
+    @patch('formation.base.BindParseValidate.validate')
+    def test_factory_doesnt_initiate_validation(self, validate):
+        cfa = Organization.objects.get(slug='cfa')
+        sub = FormSubmissionWithOrgsFactory(organizations=[cfa])
+        validate.assert_not_called()
+
+    @patch('formation.base.BindParseValidate.validate')
+    def test_application_detail_doesnt_initiate_validation(self, validate):
+        profile = app_reviewer('cc_pubdef')
+        app = make_apps_for('cc_pubdef', count=1)[0]
+        self.client.login(
+            username=profile.user.username,
+            password=settings.TEST_USER_PASSWORD)
+        self.client.get(reverse(
+            'intake-app_detail', kwargs=dict(
+                submission_id=app.form_submission_id)))
+        validate.assert_not_called()

--- a/project/settings/develop.py
+++ b/project/settings/develop.py
@@ -18,4 +18,4 @@ AWS_STORAGE_BUCKET_NAME = os.environ.get('BUCKETEER_BUCKET_NAME')
 LIVE_COUNTY_CHOICES = False
 
 # use mailgun's REST API to validate email addresses
-VALIDATE_EMAILS_WITH_MAILGUN = False
+VALIDATE_EMAILS_WITH_MAILGUN = True


### PR DESCRIPTION
Release of:
- #1230 (PR description copied below) - Permit emails with unknown verification
- And #1223 (don't validate excessively)

-----

### What does this do and why?

Mailgun will tell us whether or not an email is verified with three possible answers: `true`, `false`, and `unknown`. This treats emails marked with `unknown` verification as an acceptable answer, because applicants with working email addresses (`@yahoo.com`) were being blocked.
