### PR TITLE
Validate date to prevent errors from wrong day for month in dob

### DIFF
--- a/formation/fields.py
+++ b/formation/fields.py
@@ -4,7 +4,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.core.validators import (
     EmailValidator, URLValidator, RegexValidator, MinValueValidator,
     MaxValueValidator)
-from formation.validators import mailgun_email_validator
+from formation.validators import mailgun_email_validator, is_a_valid_date
 from intake.models import County
 from formation.field_types import (
     CharField, MultilineCharField, IntegerField, WholeDollarField, ChoiceField,
@@ -284,6 +284,7 @@ class DateOfBirthField(MultiValueField):
         Year
     ]
     display_label = "Date of birth"
+    validators = [is_a_valid_date]
 
     def get_display_value(self):
         return "{month}/{day}/{year}".format(

--- a/formation/tests/test_field_types.py
+++ b/formation/tests/test_field_types.py
@@ -552,29 +552,19 @@ class TestMultiValueField(PatchTranslationTestCase):
             field = fields.DateOfBirthField(input_data)
             self.assertParsesCorrectly(field, self.parsed_value)
 
-    def test_valid_with_missing_subkey(self):
-        for input_data in [self.missing_subkey, self.dotsep_missing_subkey]:
-            field = fields.DateOfBirthField(input_data)
-            self.assertParsesCorrectly(
-                field, self.missing_month_value, [
-                    None, 2, 1982])
+    def test_invalid_with_missing_subkey(self):
+       for input_data in [self.missing_subkey, self.dotsep_missing_subkey]:
+           field = fields.DateOfBirthField(input_data)
+           self.assertFalse(field.is_valid())
 
-    def test_valid_with_incorrect_subkey(self):
-        for input_data in [self.incorrect_subkey,
-                           self.dotsep_incorrect_subkey]:
-            field = fields.DateOfBirthField(input_data)
-            self.assertParsesCorrectly(
-                field, self.missing_month_value, [
-                    None, 2, 1982])
-
-    def test_required_only_fails_with_all_missing_data(self):
+    def test_required_fails_with_any_missing_data(self):
         only_one = {
             'dob.day': '2',
         }
         field = fields.DateOfBirthField(only_one)
-        self.assertParsesCorrectly(field,
-                                   {'year': None, 'month': None, 'day': 2},
-                                   [None, 2, None])
+        self.assertFalse(field.is_valid())
+        self.assertDictEqual(
+            field.get_current_value(), {'year': None, 'month': None, 'day': 2})
         self.assertFalse(field.is_empty())
 
         blank = {

--- a/formation/tests/test_field_types.py
+++ b/formation/tests/test_field_types.py
@@ -553,9 +553,9 @@ class TestMultiValueField(PatchTranslationTestCase):
             self.assertParsesCorrectly(field, self.parsed_value)
 
     def test_invalid_with_missing_subkey(self):
-       for input_data in [self.missing_subkey, self.dotsep_missing_subkey]:
-           field = fields.DateOfBirthField(input_data)
-           self.assertFalse(field.is_valid())
+        for input_data in [self.missing_subkey, self.dotsep_missing_subkey]:
+            field = fields.DateOfBirthField(input_data)
+            self.assertFalse(field.is_valid())
 
     def test_required_fails_with_any_missing_data(self):
         only_one = {

--- a/formation/tests/test_fields.py
+++ b/formation/tests/test_fields.py
@@ -91,6 +91,20 @@ class TestDateOfBirthField(TestCase):
         field.is_valid()
         self.assertEqual(field.get_display_value(), "134/False/foo")
 
+    def test_invalid_if_wrong_day_for_month(self):
+        data = {
+            'dob': {
+                'year': 1901,
+                'month': 2,
+                'day': 30
+            }
+        }
+        field = fields.DateOfBirthField(data)
+        self.assertFalse(field.is_valid())
+        self.assertIn(
+            "30 is not a day in that month. Please enter a valid date",
+            field.get_errors_list())
+
 
 class TestCounties(TestCase):
 

--- a/formation/validators.py
+++ b/formation/validators.py
@@ -1,3 +1,4 @@
+from datetime import date
 from formation.exceptions import NoChoicesGivenError
 from django.core.exceptions import ValidationError
 from django.core.validators import (RegexValidator,
@@ -149,3 +150,17 @@ def mailgun_email_validator(value):
             message="{}".format(err))
         format_and_log(
             'mailgun_api_error', level='error', exception=str(err))
+
+
+def is_a_valid_date(dob_dict):
+    try:
+        date(**dob_dict)
+    except (ValueError, TypeError) as err:
+        error_message = str(err)
+        if 'day is out of range for month' in error_message:
+            message = str(
+                '{} is not a day in that month. '
+                'Please enter a valid date'.format(dob_dict['day']))
+        else:
+            message = 'Please enter a valid date'
+        raise ValidationError(message)


### PR DESCRIPTION
Closes #1241 

### What does this do and why?

This fixes an error that will happen if someone enters a day that doesn't exist in a particular month for their birthdate.

### Testing & Checks

What does this PR include?
- [ ] new dependencies
- [ ] migrations
- [ ] data migrations
- [ ] celery tasks
- [ ] changes to environment variables or local settings
- [ ] configuration changes for 3rd party services (Travis, Heroku, AWS, Github, etc) 
- [ ] visual or style changes

Are there any human checks that should be used to verify these changes, such as user acceptance tests (UAT) or manual deployment checks?
No further UAT is needed (we already tested it locally).

Any integration or unit tests?
This adds a unit test to ensure we've solved this case and changes other unit tests to match our intentions.
