### PR TITLE
Sets Marin County as live

### DIFF
--- a/user_accounts/fixtures/organizations.json
+++ b/user_accounts/fixtures/organizations.json
@@ -530,7 +530,7 @@
     "is_receiving_agency": true,
     "is_accepting_applications": true,
     "is_checking_notifications": true,
-    "is_live": false,
+    "is_live": true,
     "requires_rap_sheet": false,
     "requires_declaration_letter": false,
     "show_pdf_only": false,


### PR DESCRIPTION
### What does this do and why?

This sets `is_live` to `True` on the Marin County Public Defender, thereby allowing people to apply for help in Marin.