### PR TITLE
Alert if an organization stops logging in to check applications

### DIFF
--- a/user_accounts/management/commands/alert_if_org_is_absent.py
+++ b/user_accounts/management/commands/alert_if_org_is_absent.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
                 latest_login_string = latest_login.strftime("%a %b %-d %Y")
 
                 unread_applications_count = Application.objects.filter(
-                has_been_opened=False, organization__id=org.id).count()
+                    has_been_opened=False, organization__id=org.id).count()
                 subject = "Inactive organization on {}".format(
                     settings.DEFAULT_HOST)
                 msg = "{} has not logged in since {} and has {} unopened " \
@@ -37,5 +37,4 @@ class Command(BaseCommand):
                         org.name, latest_login_string,
                         unread_applications_count)
                 if unread_applications_count > 0:
-                    send_email_to_admins(
-                        subject=subject, message=msg)
+                    send_email_to_admins(subject=subject, message=msg)

--- a/user_accounts/management/commands/alert_if_org_is_absent.py
+++ b/user_accounts/management/commands/alert_if_org_is_absent.py
@@ -1,9 +1,11 @@
 from datetime import timedelta
 
+from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.contrib.auth.models import User
 from django.utils import timezone
 
+from intake.models import Application
 from project.alerts import send_email_to_admins
 from user_accounts.models import Organization
 
@@ -16,26 +18,24 @@ class Command(BaseCommand):
         now = timezone.now()
         oldest_allowed_login_date = now - timedelta(days=20)
         for org in Organization.objects.all():
-            last_logins = User.objects.filter(
-                profile__organization__id=org.id
-            ).values_list('last_login', flat=True)
-            last_logins = [
-                login_datetime for login_datetime in last_logins
-                if login_datetime != None
-            ]
-            if last_logins:
-                latest_login = max(last_logins)
-                no_recent_logins = latest_login < oldest_allowed_login_date
+            latest_login = User.objects.filter(
+                profile__organization__id=org.id,
+                profile__organization__is_live=True,
+                last_login__isnull=False
+            ).order_by("-last_login").values_list(
+                'last_login', flat=True).first()
+
+            if latest_login and (latest_login < oldest_allowed_login_date):
                 latest_login_string = latest_login.strftime("%a %b %-d %Y")
-            else:
-                no_recent_logins = True
-                latest_login_string = 'forever'
-            unread_applications_count = Application.objects.filter(
+
+                unread_applications_count = Application.objects.filter(
                 has_been_opened=False, organization__id=org.id).count()
-            has_unread_applications = unread_applications_count > 0
-            msg = "{} has not logged in since {} and has {} unopened " \
-                  "applications".format(
-                org.name, latest_login_string, unread_applications_count)
-            if no_recent_logins and has_unread_applications:
-                send_email_to_admins(
-                    subject=msg, body="We should contact them")
+                subject = "Inactive organization on {}".format(
+                    settings.DEFAULT_HOST)
+                msg = "{} has not logged in since {} and has {} unopened " \
+                      "applications. We should contact them.".format(
+                        org.name, latest_login_string,
+                        unread_applications_count)
+                if unread_applications_count > 0:
+                    send_email_to_admins(
+                        subject=subject, message=msg)

--- a/user_accounts/management/commands/alert_if_org_is_absent.py
+++ b/user_accounts/management/commands/alert_if_org_is_absent.py
@@ -1,0 +1,41 @@
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand
+from django.contrib.auth.models import User
+from django.utils import timezone
+
+from project.alerts import send_email_to_admins
+from user_accounts.models import Organization
+
+
+class Command(BaseCommand):
+    help = str(
+        "Check if any organizations have not logged in for the past 20 days")
+
+    def handle(self, *args, **kwargs):
+        now = timezone.now()
+        oldest_allowed_login_date = now - timedelta(days=20)
+        for org in Organization.objects.all():
+            last_logins = User.objects.filter(
+                profile__organization__id=org.id
+            ).values_list('last_login', flat=True)
+            last_logins = [
+                login_datetime for login_datetime in last_logins
+                if login_datetime != None
+            ]
+            if last_logins:
+                latest_login = max(last_logins)
+                no_recent_logins = latest_login < oldest_allowed_login_date
+                latest_login_string = latest_login.strftime("%a %b %-d %Y")
+            else:
+                no_recent_logins = True
+                latest_login_string = 'forever'
+            unread_applications_count = Application.objects.filter(
+                has_been_opened=False, organization__id=org.id).count()
+            has_unread_applications = unread_applications_count > 0
+            msg = "{} has not logged in since {} and has {} unopened " \
+                  "applications".format(
+                org.name, latest_login_string, unread_applications_count)
+            if no_recent_logins and has_unread_applications:
+                send_email_to_admins(
+                    subject=msg, body="We should contact them")

--- a/user_accounts/tests/management/commands/test_alert_if_org_is_absent.py
+++ b/user_accounts/tests/management/commands/test_alert_if_org_is_absent.py
@@ -1,0 +1,85 @@
+from datetime import timedelta
+
+from django.core import mail
+from django.test import TestCase
+from django.utils import timezone
+
+from intake.tests.factories import FormSubmissionWithOrgsFactory
+from user_accounts.management.commands.alert_if_org_is_absent import Command
+from user_accounts.tests.factories import UserFactory, \
+    FakeOrganizationFactory, UserProfileFactory
+
+old_login_date = timezone.now() - timedelta(days=21)
+recent_login_date = timezone.now() - timedelta(days=19)
+
+
+class TestCommand(TestCase):
+
+    def setUp(self):
+        self.org = FakeOrganizationFactory(
+            name="Alameda County Pubdef", is_live=True)
+        self.sub = FormSubmissionWithOrgsFactory(
+            organizations=[self.org], answers={})
+
+    def run_command(self):
+        command = Command()
+        with self.settings(DEFAULT_HOST='localhost:8000'):
+            command.handle()
+
+    def test_alerts_with_old_logins_and_unopened_apps(self):
+        user1 = UserFactory(last_login=old_login_date)
+        user2 = UserFactory(last_login=old_login_date - timedelta(days=2))
+        user3 = UserFactory(last_login=None)
+        UserProfileFactory(user=user1, organization=self.org)
+        UserProfileFactory(user=user2, organization=self.org)
+        UserProfileFactory(user=user3, organization=self.org)
+        self.run_command()
+        self.assertEqual(1, len(mail.outbox))
+        email = mail.outbox[0]
+        expected_subject = "Inactive organization on localhost:8000"
+        expected_body = "Alameda County Pubdef has not logged in since " \
+                        "{} and has 1 unopened applications".format(
+                            old_login_date.strftime("%a %b %-d %Y"))
+        self.assertEqual(expected_subject, email.subject)
+        self.assertIn(expected_body, email.body)
+
+    def test_no_alert_with_no_logins_and_unopened_apps(self):
+        user1 = UserFactory(last_login=None)
+        user2 = UserFactory(last_login=None)
+        UserProfileFactory(user=user1, organization=self.org)
+        UserProfileFactory(user=user2, organization=self.org)
+        self.run_command()
+        self.assertEqual(0, len(mail.outbox))
+
+    def test_no_alert_with_old_logins_unopened_apps_and_org_not_live(self):
+        user1 = UserFactory(last_login=old_login_date)
+        user2 = UserFactory(last_login=old_login_date - timedelta(days=2))
+        user3 = UserFactory(last_login=None)
+        self.org.is_live = False
+        self.org.save()
+        UserProfileFactory(user=user1, organization=self.org)
+        UserProfileFactory(user=user2, organization=self.org)
+        UserProfileFactory(user=user3, organization=self.org)
+        self.run_command()
+        self.assertEqual(0, len(mail.outbox))
+
+    def test_no_alert_with_old_logins_but_no_unopened_apps(self):
+        user1 = UserFactory(last_login=old_login_date)
+        user2 = UserFactory(last_login=old_login_date - timedelta(days=2))
+        user3 = UserFactory(last_login=None)
+        UserProfileFactory(user=user1, organization=self.org)
+        UserProfileFactory(user=user2, organization=self.org)
+        UserProfileFactory(user=user3, organization=self.org)
+        self.sub.applications.update(has_been_opened=True)
+        self.run_command()
+        self.assertEqual(0, len(mail.outbox))
+
+    def test_no_alert_with_recent_logins_and_unopened_apps(self):
+        user1 = UserFactory(last_login=recent_login_date)
+        user2 = UserFactory(last_login=old_login_date)
+        user3 = UserFactory(last_login=None)
+        UserProfileFactory(user=user1, organization=self.org)
+        UserProfileFactory(user=user2, organization=self.org)
+        UserProfileFactory(user=user3, organization=self.org)
+        self.run_command()
+        self.assertEqual(0, len(mail.outbox))


### PR DESCRIPTION
Closes #1262 

### What does this do and why?

This adds a command that will alert us if any orgs haven't logged in for 20 days and have unread applications. We can run this command automatically on a daily basis.

### Testing & Checks

What does this PR include?
- [ ] new dependencies
- [ ] migrations
- [ ] data migrations
- [ ] celery tasks
- [ ] changes to environment variables or local settings
- [ ] configuration changes for 3rd party services (Travis, Heroku, AWS, Github, etc) 
- [ ] visual or style changes

### Deployment steps
- [x] Run on live server (with fake old logins for one org) and ensure we get the right emails.
- [ ] Run on `cmr-prod` and check the results.
- [ ] set the Heroku scheduler to run `./manage.py alert_if_org_is_absent` daily.

_Any integration or unit tests?_
This includes unit tests for the management command