### PR TITLE
Limit search queries to 3 or more characters

### DIFF
--- a/intake/static/intake/js/search_widget.js
+++ b/intake/static/intake/js/search_widget.js
@@ -26,7 +26,7 @@ function initializeSearchWidget(inputSelector, postURL, resultsCallback, emptySe
   function handleKeyupInSearchInput(e){
     var searchTerm = $(this).val();
 
-    if (searchTerm.length > 0){
+    if (searchTerm.length >= 3){
       sendSearchQuery(searchTerm);
     } else {
       emptySearchCallback();


### PR DESCRIPTION
Closes #1281 

### What does this do and why?

This changes the autocomplete for searches of applications to only run if a user has input 3 or more characters. This change will prevent single or double character searches which return so many results that they may exceed our memory quota.

### Testing & Checks

What does this PR include?
- [ ] new dependencies
- [ ] migrations
- [ ] data migrations
- [ ] celery tasks
- [ ] changes to environment variables or local settings
- [ ] configuration changes for 3rd party services (Travis, Heroku, AWS, Github, etc) 
- [ ] visual or style changes

Are there any human checks that should be used to verify these changes, such as user acceptance tests (UAT) or manual deployment checks?

- [x] Check that AJAX POST requests are not initiated until 3 characters are entered into the search input.
- [x] On prod, double check that we cannot exceed memory quotas by typing searches.

_Any integration or unit tests?_
There are no new integration or unit tests for this change.
