### PR TITLE
reduced worker processes to 2

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 release: python manage.py heroku_release
-worker: newrelic-admin run-program celery worker --app=project.celery -E --loglevel=INFO --without-gossip --without-mingle --without-heartbeat
+worker: newrelic-admin run-program celery worker --app=project.celery --concurrency=2 -E --loglevel=INFO --without-gossip --without-mingle --without-heartbeat
 web: newrelic-admin run-program gunicorn project.heroku_wsgi --log-file=-


### PR DESCRIPTION
Closes #1275 #1280
### What does this do and why?

This reduces the number of celery processes to 2 from 8.  This should solve or at the mimimum mediate our memory issues when creating pdfs and avoid potential future disruption.

### Testing & Checks

What does this PR include?
- [ ] new dependencies
- [ ] migrations
- [ ] data migrations
- [ ] celery tasks
- [ ] changes to environment variables or local settings
- [x] configuration changes for 3rd party services (Travis, Heroku, AWS, Github, etc) 
- [ ] visual or style changes


### UAT and Details

After deploy check that memory decreases and watch that the queue size doesn't increase.  

Its probably a good idea to increase the number of production workers to 2 from 1 so that number of workers total is only cut into half but this is likely overkill.
