### PR TITLE
Ensure org absence alert only runs on first of month

### DIFF
--- a/user_accounts/management/commands/alert_if_org_is_absent.py
+++ b/user_accounts/management/commands/alert_if_org_is_absent.py
@@ -12,10 +12,13 @@ from user_accounts.models import Organization
 
 class Command(BaseCommand):
     help = str(
-        "Check if any organizations have not logged in for the past 20 days")
+        "Check if any organizations have not logged in for the past 20 days. "
+        "Only runs if today is the first of the month")
 
     def handle(self, *args, **kwargs):
         now = timezone.now()
+        if now.day != 1:
+            return
         oldest_allowed_login_date = now - timedelta(days=20)
         for org in Organization.objects.all():
             latest_login = User.objects.filter(

--- a/user_accounts/tests/management/commands/test_alert_if_org_is_absent.py
+++ b/user_accounts/tests/management/commands/test_alert_if_org_is_absent.py
@@ -1,4 +1,5 @@
-from datetime import timedelta
+from datetime import timedelta, datetime
+from unittest.mock import patch, Mock
 
 from django.core import mail
 from django.test import TestCase
@@ -9,8 +10,18 @@ from user_accounts.management.commands.alert_if_org_is_absent import Command
 from user_accounts.tests.factories import UserFactory, \
     FakeOrganizationFactory, UserProfileFactory
 
-old_login_date = timezone.now() - timedelta(days=21)
-recent_login_date = timezone.now() - timedelta(days=19)
+first_of_the_month = timezone.make_aware(datetime(year=2017, month=9, day=1))
+not_first_of_the_month = timezone.make_aware(
+    datetime(year=2017, month=9, day=2))
+
+old_login_date = first_of_the_month - timedelta(days=21)
+recent_login_date = first_of_the_month - timedelta(days=19)
+
+
+def mock_timezone_with(return_value):
+    mock_timezone = Mock()
+    mock_timezone.now.return_value = return_value
+    return mock_timezone
 
 
 class TestCommand(TestCase):
@@ -26,6 +37,9 @@ class TestCommand(TestCase):
         with self.settings(DEFAULT_HOST='localhost:8000'):
             command.handle()
 
+    @patch(
+        'user_accounts.management.commands.alert_if_org_is_absent.timezone',
+        mock_timezone_with(first_of_the_month))
     def test_alerts_with_old_logins_and_unopened_apps(self):
         user1 = UserFactory(last_login=old_login_date)
         user2 = UserFactory(last_login=old_login_date - timedelta(days=2))
@@ -43,6 +57,9 @@ class TestCommand(TestCase):
         self.assertEqual(expected_subject, email.subject)
         self.assertIn(expected_body, email.body)
 
+    @patch(
+        'user_accounts.management.commands.alert_if_org_is_absent.timezone',
+        mock_timezone_with(first_of_the_month))
     def test_no_alert_with_no_logins_and_unopened_apps(self):
         user1 = UserFactory(last_login=None)
         user2 = UserFactory(last_login=None)
@@ -51,6 +68,9 @@ class TestCommand(TestCase):
         self.run_command()
         self.assertEqual(0, len(mail.outbox))
 
+    @patch(
+        'user_accounts.management.commands.alert_if_org_is_absent.timezone',
+        mock_timezone_with(first_of_the_month))
     def test_no_alert_with_old_logins_unopened_apps_and_org_not_live(self):
         user1 = UserFactory(last_login=old_login_date)
         user2 = UserFactory(last_login=old_login_date - timedelta(days=2))
@@ -63,6 +83,9 @@ class TestCommand(TestCase):
         self.run_command()
         self.assertEqual(0, len(mail.outbox))
 
+    @patch(
+        'user_accounts.management.commands.alert_if_org_is_absent.timezone',
+        mock_timezone_with(first_of_the_month))
     def test_no_alert_with_old_logins_but_no_unopened_apps(self):
         user1 = UserFactory(last_login=old_login_date)
         user2 = UserFactory(last_login=old_login_date - timedelta(days=2))
@@ -74,6 +97,9 @@ class TestCommand(TestCase):
         self.run_command()
         self.assertEqual(0, len(mail.outbox))
 
+    @patch(
+        'user_accounts.management.commands.alert_if_org_is_absent.timezone',
+        mock_timezone_with(first_of_the_month))
     def test_no_alert_with_recent_logins_and_unopened_apps(self):
         user1 = UserFactory(last_login=recent_login_date)
         user2 = UserFactory(last_login=old_login_date)
@@ -83,3 +109,24 @@ class TestCommand(TestCase):
         UserProfileFactory(user=user3, organization=self.org)
         self.run_command()
         self.assertEqual(0, len(mail.outbox))
+
+    @patch(
+        'user_accounts.management.commands.alert_if_org_is_absent.timezone',
+        mock_timezone_with(not_first_of_the_month))
+    @patch(
+        'user_accounts.management.commands.alert_if_org_is_absent.timedelta')
+    @patch(
+        'user_accounts.management.commands.alert_if_org_is_absent.Organization'
+    )
+    def test_does_nothing_if_not_first_of_month(
+                self, mock_Organization, mock_timedelta):
+        user1 = UserFactory(last_login=old_login_date)
+        user2 = UserFactory(last_login=old_login_date - timedelta(days=2))
+        user3 = UserFactory(last_login=None)
+        UserProfileFactory(user=user1, organization=self.org)
+        UserProfileFactory(user=user2, organization=self.org)
+        UserProfileFactory(user=user3, organization=self.org)
+        self.run_command()
+        self.assertEqual(0, len(mail.outbox))
+        mock_Organization.assert_not_called()
+        mock_timedelta.assert_not_called()


### PR DESCRIPTION
Closes #1284 

### What does this do and why?

We have a command that alerts us if an org hasn't logged in recently and has unopened apps. This modifies the command to only alert us if it's the first of the month, so we don't get overwhelmed with redundant alerts.

### Deployment Steps

- [ ] Once deployed, we should set up Heroku Scheduler to run `./manage.py alert_if_org_is_absent` daily at 10 AM Pacific (17:00 UTC)