### PR TITLE
Hotfix/turn off mailgun staging

### DIFF
--- a/helper_commands/management/commands/send_front_notifications_from_logs.py
+++ b/helper_commands/management/commands/send_front_notifications_from_logs.py
@@ -1,0 +1,42 @@
+import json
+import csv
+
+from django.conf import settings
+from django.core.management import BaseCommand
+from requests import request
+
+
+class Command(BaseCommand):
+    help = str(
+        "Scrapes logs for FRONT POST and sends messages."
+        "This was created to recover from the scenario where "
+        "DIVERT_REMOTE_CONNECTIONS was accidentally set to True on production")
+
+    def handle(self, *args, **kwargs):
+        FRONT_EMAIL_CHANNEL_ID = 'cha_ok0'
+        FRONT_PHONE_CHANNEL_ID = 'cha_nx8'
+
+        with open('./logs_temp/front_posts.tsv', 'r') as csvfile:
+            spamreader = csv.reader(csvfile, delimiter='\t')
+            for row in spamreader:
+                post = row[9][11:]
+                post_json = json.loads(post)
+                to_field = post_json['to'][0]
+
+                is_email = '@' in to_field
+                if is_email:
+                    channel_id = FRONT_EMAIL_CHANNEL_ID
+                else:
+                    channel_id = FRONT_PHONE_CHANNEL_ID
+                root_url = 'https://api2.frontapp.com/channels/{}/messages'\
+                    .format(channel_id)
+                print("Sending {} to {}".format(is_email, to_field))
+                request(url=root_url,
+                        data=post,
+                        method='POST',
+                        headers={
+                            'Authorization': 'Bearer {}'.format(getattr(
+                                settings, 'FRONT_API_TOKEN', None)),
+                            'Accept': 'application/json',
+                            'Content-Type': 'application/json'
+                        })

--- a/project/decorators.py
+++ b/project/decorators.py
@@ -1,5 +1,10 @@
+import logging
 from functools import wraps
 from django.conf import settings
+
+
+# Get an instance of a logger
+logger = logging.getLogger(__name__)
 
 
 def run_if_setting_true(setting_name, alternate_return_value):
@@ -7,6 +12,9 @@ def run_if_setting_true(setting_name, alternate_return_value):
         @wraps(func)
         def wrapped(*args, **kwargs):
             if not getattr(settings, setting_name, False):
+                logger.info(
+                    "{} caused skipped function call {}".
+                    format(setting_name, func.__name__))
                 return alternate_return_value
             return func(*args, **kwargs)
         return wrapped

--- a/project/settings/prod.py
+++ b/project/settings/prod.py
@@ -37,8 +37,8 @@ DEBUG = False
 # hides counties where none of the orgs are officially live
 LIVE_COUNTY_CHOICES = True
 
-# use mailgun's REST API
-ALLOW_REQUESTS_TO_MAILGUN = True
 
 DIVERT_REMOTE_CONNECTIONS = os.environ.get(
                             'DIVERT_REMOTE_CONNECTIONS', 'True') == 'True'
+
+ALLOW_REQUESTS_TO_MAILGUN = not DIVERT_REMOTE_CONNECTIONS


### PR DESCRIPTION
Closes #1305 

This sets ALLOW_REQUEST_TO_MAILGUN equal to the opposite of DIVERT_REMOTE_CONNECTIONS

It also adds a log whenever a call to mailgun is skipped because of settings.