### PR TITLE
Begin using Sentry's environments

### DIFF
--- a/app.json
+++ b/app.json
@@ -75,6 +75,9 @@
     "SENTRY_URL": {
       "required": true
     },
+    "SENTRY_ENVIRONMENT": {
+      "value": "review"
+    },
     "SERVER_EMAIL": {
       "required": true
     },

--- a/project/settings/deployed.py
+++ b/project/settings/deployed.py
@@ -90,6 +90,7 @@ LOGGING = {
 # Initialize Sentry
 sentry_sdk.init(
     dsn=SENTRY_URL,
+    environment=SENTRY_ENVIRONMENT,
     integrations=[
         DjangoIntegration(),
         CeleryIntegration()

--- a/project/settings/environment.py
+++ b/project/settings/environment.py
@@ -41,6 +41,7 @@ CELERY_BROKER_URL = os.environ.get('CLOUDAMQP_URL')
 
 TEST_USER_PASSWORD = os.environ.get("TEST_USER_PASSWORD")
 SENTRY_URL = os.environ.get("SENTRY_URL")
+SENTRY_ENVIRONMENT = os.environ.get("SENTRY_ENVIRONMENT")
 
 # hides counties where none of the orgs are officially live
 ONLY_SHOW_LIVE_COUNTIES = os.environ.get('ONLY_SHOW_LIVE_COUNTIES', 'True') == 'True'


### PR DESCRIPTION
The intention is to use one Sentry project for CMR Classic, then use environments to differentiate environments (e.g. review, staging, production). This should enable us to more easily track problems across environments.

Here's the Sentry documentation about the feature: https://docs.sentry.io/enriching-error-data/environments/?platform=python