### PR TITLE
Remove unnecessary(?) dependency

### DIFF
--- a/requirements/app.txt
+++ b/requirements/app.txt
@@ -40,7 +40,6 @@ certifi==2019.11.28
 click==7.0
 factory-boy==2.12.0
 Faker==1.0.7
-cryptography==2.8
 idna==2.8
 whitenoise==5.0.1
 celery==4.4.3


### PR DESCRIPTION
cryptography package had a security vulnerability in the version we had
pinned, but it seems to be a nested dependency anyway (or we're not using it?) so this 
removes the requirement in the hopes that either we actually aren't using it or the host 
package will resolve the cryptography dependency to a secure version.

[#175619039]